### PR TITLE
Reset release-please manifest for initial 0.1.0 across packages

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,1 @@
-{
-  "confidence-resolver": "0.1.0",
-  "confidence-cloudflare-resolver": "0.1.0",
-  "wasm-msg": "0.1.0"
-}
-
+{}


### PR DESCRIPTION
This resets .release-please-manifest.json to {} so the next Release Please run treats all packages as first releases using initial-version=0.1.0.