### PR TITLE
feat: WIP provider versioning and releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,35 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Pre-bump providers if resolver changed since last tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          LAST_TAG=$(git tag --list 'confidence_resolver-v*' | sort -V | tail -n1 || true)
+          CHANGED=true
+          if [ -n "${LAST_TAG:-}" ]; then
+            if git diff --quiet "${LAST_TAG}"..HEAD -- confidence-resolver; then
+              CHANGED=false
+            fi
+          fi
+          if [ "$CHANGED" = true ]; then
+            mkdir -p openfeature-provider/js openfeature-provider/java
+            SHA=$(git rev-parse --short HEAD)
+            echo "$SHA" > openfeature-provider/js/CONFIDENCE_RESOLVER_ADOPTED_SHA
+            echo "$SHA" > openfeature-provider/java/CONFIDENCE_RESOLVER_ADOPTED_SHA
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add openfeature-provider/js/CONFIDENCE_RESOLVER_ADOPTED_SHA openfeature-provider/java/CONFIDENCE_RESOLVER_ADOPTED_SHA
+            if git diff --cached --quiet; then
+              echo "No provider marker changes to commit"
+            else
+              git commit -m "fix: adopt latest confidence-resolver changes"
+              git push
+            fi
+          else
+            echo "confidence-resolver unchanged since last tag; skipping provider bump"
+          fi
+
       - name: Release Please (manifest)
         id: release
         uses: googleapis/release-please-action@v4
@@ -34,6 +63,8 @@ jobs:
     needs: release
     if: ${{ needs.release.outputs.releases_created == 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      resolver_version: ${{ steps.extract_version.outputs.resolver_version }}
     permissions:
       contents: write
       packages: read
@@ -57,6 +88,7 @@ jobs:
           VERSION=$(grep -m1 '^version\s*=\s*"' confidence-resolver/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "TAG_NAME=confidence_resolver-v$VERSION" >> $GITHUB_ENV
+          echo "resolver_version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Build and extract WASM artifact
         uses: docker/build-push-action@v6
@@ -127,3 +159,47 @@ jobs:
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  providers-smoke-build:
+    needs: [release, publish-wasm]
+    if: ${{ needs.release.outputs.releases_created == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      CONFIDENCE_RESOLVER_VERSION: ${{ needs.publish-wasm.outputs.resolver_version }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Pin resolver version in JS package.json
+        run: |
+          jq ".confidenceResolverVersion=\"${{ needs.publish-wasm.outputs.resolver_version }}\"" openfeature-provider/js/package.json > openfeature-provider/js/package.json.tmp
+          mv openfeature-provider/js/package.json.tmp openfeature-provider/js/package.json
+
+      - name: Pin resolver version in Java pom.xml
+        run: |
+          sed -i.bak "s#<confidence.resolver.version>.*</confidence.resolver.version>#<confidence.resolver.version>${{ needs.publish-wasm.outputs.resolver_version }}</confidence.resolver.version>#" openfeature-provider/java/pom.xml
+          rm -f openfeature-provider/java/pom.xml.bak
+
+      - name: Commit resolver version pins
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add openfeature-provider/js/package.json openfeature-provider/java/pom.xml
+          if git diff --cached --quiet; then
+            echo "No resolver version pin changes"
+          else
+            git commit -m "fix: pin providers to confidence-resolver v${{ needs.publish-wasm.outputs.resolver_version }}"
+            git push
+          fi
+
+      - name: JS provider build (fetch released wasm)
+        run: make -C openfeature-provider/js build
+
+      - name: Java provider build (fetch released wasm)
+        run: make -C openfeature-provider/java build
+

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"confidence-resolver":"0.5.2","confidence-cloudflare-resolver":"0.2.7","wasm-msg":"0.2.0","wasm/rust-guest":"0.1.8","openfeature-provider-local-java":"0.6.4"}
+{"confidence-resolver":"0.5.2","confidence-cloudflare-resolver":"0.2.7","wasm-msg":"0.2.0","wasm/rust-guest":"0.1.8","openfeature-provider/java":"0.6.4","openfeature-provider/js":"0.0.1"}

--- a/openfeature-provider/java/Makefile
+++ b/openfeature-provider/java/Makefile
@@ -5,6 +5,7 @@ ROOT := $(realpath $(CURDIR)/../..)
 
 # Stamps and inputs
 BUILD_STAMP := .build.stamp
+INSTALL_STAMP := .install.stamp
 SRC := $(shell find src -name '*.java' 2>/dev/null)
 RESOURCES_WASM := src/main/resources/wasm/confidence_resolver.wasm
 LOCAL_WASM := $(ROOT)/wasm/confidence_resolver.wasm
@@ -19,13 +20,33 @@ build-wasm:
 $(BUILD_STAMP): | build-wasm
 endif
 
-$(RESOURCES_WASM): $(LOCAL_WASM)
+ifneq ($(IN_DOCKER_BUILD),1)
+$(RESOURCES_WASM):
 	@mkdir -p $(dir $@)
-	@cp -p $(LOCAL_WASM) $@
+	cp $(LOCAL_WASM) $@
+else
+# In Docker, copy the pre-staged WASM into resources
+$(RESOURCES_WASM):
+	@mkdir -p $(dir $@)
+	@test -f $(LOCAL_WASM) || (echo "Missing $(LOCAL_WASM) (expected via Docker COPY)"; exit 1)
+	cp $(LOCAL_WASM) $@
+endif
 
-$(BUILD_STAMP): pom.xml $(RESOURCES_WASM) $(SRC)
-	mvn package -DskipTests
-	@touch $@
+# A lightweight install target to prep resources
+$(INSTALL_STAMP): pom.xml $(RESOURCES_WASM)
+	touch $@
+
+
+$(BUILD_STAMP): $(INSTALL_STAMP) pom.xml $(SRC)
+	mvn -q -DskipTests protobuf:compile
+	@if [ -f "$(GEN_MESSAGES)" ]; then \
+		mkdir -p src/main/java/com/spotify/confidence/wasm; \
+		cp $(GEN_MESSAGES) src/main/java/com/spotify/confidence/wasm/Messages.java; \
+	fi
+	mvn -q -DskipTests package
+	touch $@
+
+install: $(INSTALL_STAMP)
 
 build: $(BUILD_STAMP)
 
@@ -35,6 +56,7 @@ test: $(BUILD_STAMP)
 clean:
 	mvn -q clean
 	rm -f $(BUILD_STAMP)
+	rm -f $(INSTALL_STAMP)
 	rm -f $(RESOURCES_WASM)
 
 

--- a/openfeature-provider/java/pom.xml
+++ b/openfeature-provider/java/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.spotify.confidence</groupId>
   <artifactId>openfeature-provider-local</artifactId>
-  <version>0.0.0-SNAPSHOT</version>
+  <version>0.6.5-SNAPSHOT</version>
   <name>Confidence local resolve provider</name>
 
   <properties>
@@ -13,6 +13,7 @@
     <!-- Prevents the compiler version from resetting locally in Intellij -->
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
+    <confidence.resolver.version>0.5.2</confidence.resolver.version>
     <protobuf.version>3.25.3</protobuf.version>
     <grpc.version>1.63.0</grpc.version>
     <slf4j.version>2.0.13</slf4j.version>
@@ -185,6 +186,16 @@
       </extension>
     </extensions>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.3.1</version>
+        <configuration>
+          <filters>
+            <filter>src/main/filters/confidence.properties</filter>
+          </filters>
+        </configuration>
+      </plugin>
       <!-- Generate Java and gRPC sources from local .proto files -->
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>

--- a/openfeature-provider/java/src/main/filters/confidence.properties
+++ b/openfeature-provider/java/src/main/filters/confidence.properties
@@ -1,0 +1,1 @@
+confidence.resolver.version=${confidence.resolver.version}

--- a/openfeature-provider/js/Makefile
+++ b/openfeature-provider/js/Makefile
@@ -23,6 +23,23 @@ build-wasm:
 $(BUILD_STAMP): | build-wasm
 endif
 
+$(WASM_ARTIFACT):
+	@mkdir -p $(dir $@)
+	@if [ -n "$$CONFIDENCE_RESOLVER_VERSION" ]; then \
+	  REPO="$$CONFIDENCE_RESOLVER_REPO"; \
+	  if [ -z "$$REPO" ]; then REPO="$$GITHUB_REPOSITORY"; fi; \
+	  if [ -z "$$REPO" ]; then REPO=$(shell git config --get remote.origin.url | sed -E 's#.*[:/]([^/]+/[^/]+?)(\\.git)?$#\\1#'); fi; \
+	  URL="https://github.com/$$REPO/releases/download/confidence_resolver-v$$CONFIDENCE_RESOLVER_VERSION/confidence_resolver.wasm"; \
+	  echo "Downloading WASM from $$URL"; \
+	  if [ -n "$$GITHUB_TOKEN" ]; then \
+	    curl -fsSL -H "Authorization: Bearer $$GITHUB_TOKEN" -o $@ "$$URL"; \
+	  else \
+	    curl -fsSL -o $@ "$$URL"; \
+	  fi; \
+	else \
+	  $(MAKE) -C $(ROOT) wasm/confidence_resolver.wasm; \
+	fi
+
 # Install dependencies only when package manifests change
 $(INSTALL_STAMP): package.json yarn.lock
 	yarn install --immutable

--- a/openfeature-provider/js/package.json
+++ b/openfeature-provider/js/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@spotify-confidence/openfeature-server-provider-local",
-  "version": "0.0.0",
+  "version": "0.0.1",
+  "confidenceResolverVersion": "0.5.2",
   "private": true,
   "description": "Spotify Confidence Open Feature provider",
   "type": "module",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bump-minor-pre-major": true,
   "plugins": ["cargo-workspace"],
+  "separate-pull-requests": false,
   "packages": {
     "confidence-resolver": {
       "path": "confidence-resolver",
@@ -27,9 +28,14 @@
       "changelog-path": "CHANGELOG.md",
       "initial-version": "0.1.0"
     },
-    "openfeature-provider-local-java": {
+    "openfeature-provider/java": {
       "path": "openfeature-provider/java",
       "release-type": "java",
+      "changelog-path": "CHANGELOG.md"
+    },
+    "openfeature-provider/js": {
+      "path": "openfeature-provider/js",
+      "release-type": "node",
       "changelog-path": "CHANGELOG.md"
     }
   }


### PR DESCRIPTION
Automates and standardizes releases for the OpenFeature providers (Java and JS) via release-please and build tooling updates. Streamlines versioning, tagging, and publish steps; aligns dependency/version propagation across packages.

When a change in the confidence-resolver is detected, release please will create a small file in the providers' path to ensure that a new version will be created for them (even if there is no code change in the providers' source code itself).

After the release PR is merged, the confidence-resolver version is pinned in the Java and JS providers, so that when the final JAR and tarball will be built they will embed the wasm with the pinned version in them.

Example release PR: https://github.com/fabriziodemaria/confidence-resolver-rust/pull/2