### PR TITLE
docs: convert ASCII flowcharts to Mermaid format

### DIFF
--- a/STICKY_ASSIGNMENTS.md
+++ b/STICKY_ASSIGNMENTS.md
@@ -84,7 +84,6 @@ flowchart TD
     SegmentMatch2{Segment Match?}
     ReturnSticky[Return Sticky Assignment<br/>no updates]
     SkipRule2[Skip Rule]
-    SkipRule3[Skip Rule]
     CalcBucket[Calculate Bucket &<br/>Find Assignment]
     AssignmentFound{Assignment Found?}
     SkipRule4[Skip Rule]
@@ -93,7 +92,7 @@ flowchart TD
     ReturnAssignment[Return Assignment<br/>with Updates]
 
     Start --> ReadSpec
-    ReadSpec -->|NO| CheckSegment2
+    ReadSpec -->|NO| CheckMatMatched
     ReadSpec -->|YES| GetInfo
     GetInfo --> InfoFound
     InfoFound -->|NOT FOUND| MissingError


### PR DESCRIPTION
## Summary
Convert sticky assignments flowcharts from ASCII art to Mermaid diagrams for better rendering in GitHub and other markdown viewers.

### Changes
- **Detailed Resolution Flowchart**: Converted the complex single-rule sticky assignment logic from ASCII to Mermaid
- **Multi-Flag Resolution Flow**: Converted the multi-flag resolution flow diagram to Mermaid

### Benefits
- Better visual rendering in GitHub PR reviews and documentation
- Easier to maintain and update
- More accessible across different platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)