### PR TITLE
ci: clean up & update conditions in release please jobs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,9 +13,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      releases_created: ${{ steps.release.outputs.releases_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
+      cloudflare_resolver_release_created: ${{ steps.releasemanifest.outputs['confidence-cloudflare-resolver--release_created'] }}
+      java_provider_release_created: ${{ steps.releasemanifest.outputs['openfeature-provider/java--release_created'] }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Release Please (manifest)
-        id: release
+        id: releasemanifest
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -34,63 +33,15 @@ jobs:
         run: |
           echo "=== Release Please Outputs ==="
           echo "All outputs (JSON):"
-          echo '${{ toJSON(steps.release.outputs) }}'
+          echo '${{ toJSON(steps.releasemanifest.outputs) }}'
           echo ""
           echo "Key outputs:"
-          echo "release_created: ${{ steps.release.outputs.release_created }}"
-          echo "releases_created: ${{ steps.release.outputs.releases_created }}"
-          echo "tag_name: ${{ steps.release.outputs.tag_name }}"
-          echo "prs_created: ${{ steps.release.outputs.prs_created }}"
-
-  publish-wasm:
-    needs: release
-    if: ${{ needs.release.outputs.releases_created == 'true' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      packages: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract confidence_resolver version and tag
-        id: extract_version
-        run: |
-          VERSION=$(grep -m1 '^version\s*=\s*"' confidence-resolver/Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/')
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "TAG_NAME=confidence_resolver-v$VERSION" >> $GITHUB_ENV
-
-      - name: Build and extract WASM artifact
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          target: wasm-rust-guest.artifact
-          outputs: type=local,dest=./artifacts
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cache:main
-          # Note: No cache-to - releases only consume cache, don't update it
-
-      - name: Upload WASM to GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ env.TAG_NAME }}
-          files: |
-            artifacts/confidence_resolver.wasm
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          echo "cloudflare_resolver_release_created: ${{ steps.releasemanifest.outputs.cloudflare_resolver_release_created }}"
+          echo "java_provider_release_created: ${{ steps.releasemanifest.outputs.java_provider_release_created }}"
 
   publish-cloudflare-deployer-image:
     needs: release
-    if: ${{ needs.release.outputs.releases_created == 'true' }}
+    if: ${{ needs.release.outputs.cloudflare_resolver_release_created == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -143,13 +94,11 @@ jobs:
   publish-java-provider-release:
     needs: release
     runs-on: ubuntu-latest
-    if: ${{ needs.release.outputs.releases_created == 'true' && needs.release.outputs['openfeature-provider-java--release_created'] == 'true' }}
+    if: ${{ needs.release.outputs.java_provider_release_created == 'true' }}
     steps:
       - name: Checkout release tag
         uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.release.outputs['openfeature-provider-java--tag_name'] }}
-
+        
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
* Define outputs from the release job to only what we now need (`cloudflare_resolver_release_created` & `java_provider_release_created `) -- use these in conditions
* renamed the `release` step to not mix it up with the job.
* drop the publish-wasm job completely.