### PR TITLE
ci: Change gpg password config in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -477,7 +477,7 @@ RUN --mount=type=secret,id=maven_settings,target=/root/.m2/settings.xml \
     # Import GPG key
     cat /run/secrets/gpg_private_key | gpg --batch --import && \
     # Deploy to Maven Central
-    GPG_PASS=$(cat /run/secrets/gpg_pass) mvn --batch-mode deploy
+    mvn -Dgpg.passphrase="$(cat /run/secrets/gpg_pass)" --batch-mode deploy
 
 # ==============================================================================
 # All - Build and validate everything (default target)


### PR DESCRIPTION
Formatting of the `MAVEN_SETTINGS` Github Repository Secret:
```
<?xml version="1.0" encoding="UTF-8"?>
<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
                      http://maven.apache.org/xsd/settings-1.0.0.xsd">

  <servers>
    <!-- Maven Central credentials -->
    <server>
      <id>central</id>
      <username>...</username>
      <password>...</password>
    </server>

    <!-- GPG passphrase -->
    <server>
      <id>gpg.passphrase</id>
      <password>...</password>
    </server>
  </servers>

</settings>
```

- The `server` credentials can be created at https://central.sonatype.com/usertoken (Generate User Token)
- The GPG Passphrase is currently privately store.

Finally, the gpg private key can be generated locally via
```
gpg --armor --export-secret-keys EC5F675909B845F4D3308FEC3768916F51F5E9E9
```
(on a machine with the expected gpg private key available).

✔️ Tested by running the deploy step locally via the same Docker command in Dockerfile