### PR TITLE
ci: potential fix for code scanning alert

### DIFF
--- a/.github/workflows/lint-pr-name.yaml
+++ b/.github/workflows/lint-pr-name.yaml
@@ -1,4 +1,7 @@
 name: 'Lint PR name'
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   pull_request_target:


### PR DESCRIPTION
Potential fix for [https://github.com/spotify/confidence-resolver-rust/security/code-scanning/1](https://github.com/spotify/confidence-resolver-rust/security/code-scanning/1)

To fix this problem, an explicit `permissions` block should be added in the workflow file. This block limits the scope of the `GITHUB_TOKEN` to the minimal permissions necessary for the workflow to work—specifically, the ability to read repository contents and write to pull requests (leave comments). The best place to add this is at the root level of the YAML file, just below the workflow `name` field (and above `on:`), so the permissions apply to all jobs in the workflow unless overridden at the job level. This is a non-disruptive change and does not affect any functional logic in the workflow—just the security context it operates under.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
