### PR TITLE
fix(go): configure release-please for correct Go module tags

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "The openfeature-provider/go/confidence key uses the full module path (not just openfeature-provider/go) to ensure release-please creates tags in the format 'openfeature-provider/go/confidence/v{version}', which is required for Go modules in subdirectories to be properly resolved by the go command.",
   "confidence-resolver": "0.6.0",
   "confidence-cloudflare-resolver": "0.3.0",
   "wasm-msg": "0.2.1",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -45,6 +45,7 @@
       "extra-files": ["package.json"]
     },
     "openfeature-provider/go/confidence": {
+      "_comment": "The component name and path use the full module path (openfeature-provider/go/confidence) rather than just the directory (openfeature-provider/go). This ensures tags are created as 'openfeature-provider/go/confidence/v{version}', which is the format required by Go for submodule versioning. The include-component-in-tag setting ensures the full path is included in the tag name.",
       "path": "openfeature-provider/go/confidence",
       "release-type": "rust",
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Summary

Updates the release-please configuration to create tags in the correct format for Go modules in subdirectories.

## Changes

- Changed package key from `openfeature-provider/go` to `openfeature-provider/go/confidence` (needed since this is what decides the tag name)
- Updated path to match the actual Go module location (needed by Go dep resolution)
- Added `include-component-in-tag: true` to ensure component path is included in tags
- Removed `initial-version` field

## Impact

**Before:** Tags created as `openfeature-provider-go-v0.1.0`
- Go cannot resolve these tags
- Users must use commit hashes or pseudo-versions

**After:** Tags created as `openfeature-provider/go/confidence/v0.1.0`
- Go can properly resolve semantic versions
- Users can use: `go get github.com/spotify/confidence-resolver/openfeature-provider/go/confidence@v0.1.0`

## User Experience

With this change, users can add the Go provider with standard Go commands:

```bash
go get github.com/spotify/confidence-resolver/openfeature-provider/go/confidence@v0.1.0
```

Or in their go.mod:
```go
require github.com/spotify/confidence-resolver/openfeature-provider/go/confidence v0.1.0
```