### PR TITLE
feat: add resolve counter to telemetry data

### DIFF
--- a/confidence-resolver/protos/confidence/flags/resolver/v1/internal_api.proto
+++ b/confidence-resolver/protos/confidence/flags/resolver/v1/internal_api.proto
@@ -83,6 +83,12 @@ message WriteFlagLogsRequest {
   repeated confidence.flags.admin.v1.FlagResolveInfo flag_resolve_info = 4 [
     (google.api.field_behavior) = OPTIONAL
   ];
+
+  // Number of resolve operations since the last flush/checkpoint.
+  // This counter is reset when logs are retrieved by the application.
+  int64 resolve_count = 5 [
+    (google.api.field_behavior) = OPTIONAL
+  ];
 }
 
 message WriteFlagLogsResponse {}

--- a/confidence-resolver/src/flag_logger.rs
+++ b/confidence-resolver/src/flag_logger.rs
@@ -13,8 +13,10 @@ pub fn aggregate_batch(message_batch: Vec<WriteFlagLogsRequest>) -> WriteFlagLog
     // map of flag to flag resolve info
     let mut flag_resolve_map: HashMap<String, VariantRuleResolveInfo> = HashMap::new();
     let mut flag_assigned: Vec<FlagAssigned> = vec![];
+    let mut total_resolve_count: i64 = 0;
 
     for flag_logs_message in message_batch {
+        total_resolve_count = total_resolve_count.saturating_add(flag_logs_message.resolve_count);
         for c in &flag_logs_message.client_resolve_info {
             if let Some(set) = schema_map.get_mut(&c.client_credential) {
                 for schema in &c.schema {
@@ -96,6 +98,7 @@ pub fn aggregate_batch(message_batch: Vec<WriteFlagLogsRequest>) -> WriteFlagLog
         flag_assigned,
         flag_resolve_info,
         client_resolve_info,
+        resolve_count: total_resolve_count,
     }
 }
 


### PR DESCRIPTION
Add a counter that tracks the number of resolve operations in the WASM implementation. The counter is stored in memory and included in the telemetry data when logs are returned to the application layer, then automatically reset on checkpoint.

Changes:
- Add resolve_count field to TelemetryData protobuf message
- Add resolve_count atomic counter to ResolveInfoState
- Increment counter on each log_resolve call
- Include counter in TelemetryData when building WriteFlagLogsRequest
- Reset counter automatically when checkpoint swaps state
- Add test to verify counter increments and resets correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)