### PR TITLE
feat: set the nr of wasm instances with an env var

### DIFF
--- a/openfeature-provider/java/README.md
+++ b/openfeature-provider/java/README.md
@@ -54,8 +54,9 @@ String value = client.getStringValue("my-flag", "default-value");
 Configure the provider behavior using environment variables:
 
 - `CONFIDENCE_RESOLVER_POLL_INTERVAL_SECONDS`: How often to poll Confidence to get updates (default: `300` seconds)
+- `CONFIDENCE_NUMBER_OF_WASM_INSTANCES`: How many WASM instances to create (this defaults to `Runtime.getRuntime().availableProcessors()` and will affect the performance of the provider)
 
-// Deprecated in favour of a custom ChannelFactory:
+##### Deprecated in favour of a custom ChannelFactory:
 - `CONFIDENCE_DOMAIN`: Override the default Confidence service endpoint (default: `edge-grpc.spotify.com`)
 - `CONFIDENCE_GRPC_PLAINTEXT`: Use plaintext gRPC connections instead of TLS (default: `false`)
 

--- a/openfeature-provider/java/src/main/java/com/spotify/confidence/ThreadLocalSwapWasmResolverApi.java
+++ b/openfeature-provider/java/src/main/java/com/spotify/confidence/ThreadLocalSwapWasmResolverApi.java
@@ -6,6 +6,7 @@ import com.spotify.confidence.flags.resolver.v1.ResolveFlagsResponse;
 import com.spotify.futures.CompletableFutures;
 import java.util.ArrayList;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -40,8 +41,16 @@ class ThreadLocalSwapWasmResolverApi implements ResolverApi {
     this.flagLogger = flagLogger;
     this.stickyResolveStrategy = stickyResolveStrategy;
 
+    this.numInstances = getNumInstances();
+  }
+
+  private static int getNumInstances() {
     // Pre-create instances based on CPU core count for optimal performance
-    this.numInstances = Runtime.getRuntime().availableProcessors();
+    final var defaultNumberOfInstances = Runtime.getRuntime().availableProcessors();
+
+    return Optional.ofNullable(System.getenv("CONFIDENCE_NUMBER_OF_WASM_INSTANCES"))
+                    .map(Integer::parseInt)
+                    .orElse(defaultNumberOfInstances);
   }
 
   @Override


### PR DESCRIPTION
Setting this to a lower number when testing significantly improves init speed.