### PR TITLE
fix(go): Fail hard on empty AccoundId

### DIFF
--- a/openfeature-provider/go/confidence/local_resolver_provider.go
+++ b/openfeature-provider/go/confidence/local_resolver_provider.go
@@ -394,8 +394,8 @@ func (p *LocalResolverProvider) Init(evaluationContext openfeature.EvaluationCon
 	}
 
 	if accountId == "" {
-		p.logger.Warn("AccountID is empty after state fetch")
-		accountId = "unknown"
+		p.logger.Error("AccountID is empty in the fetched state, this should not happen")
+		return fmt.Errorf("AccountID is empty in the initial state")
 	}
 
 	// Update resolver with initial state (triggers WASM compilation and initialization)


### PR DESCRIPTION
Account Id needs to be correct in order to provider the correct evaluations