### PR TITLE
docs: add binary provenance and supply chain security documentation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,3 +14,153 @@ If you have discovered a vulnerability in this open source project or another se
 please submit it to the Spotify bounty program hosted by HackerOne.
 
 https://hackerone.com/spotify
+
+---
+
+## Binary Provenance and Supply Chain Security
+
+This repository implements binary provenance to ensure transparency and trust in our WebAssembly (WASM) resolver that is embedded in our OpenFeature provider packages.
+
+### The Challenge
+
+Our Java, JavaScript, and Go provider packages include a pre-compiled WASM binary (`confidence_resolver.wasm`). While this provides convenience and performance, it creates a "black box" problem: how can users verify that the binary corresponds to the source code in this repository?
+
+### Our Solution: Provenance Attestation
+
+We use **reproducible builds** and **GitHub attestations** to create a verifiable chain of custody from source code to distributed binaries.
+
+## Verifying the WASM Binary
+
+### 1. Download the Published WASM
+
+Each provider release includes the canonical WASM binary and its SHA-256 checksum as release assets:
+
+```bash
+# Example: For Java provider version 0.8.0
+gh release download openfeature-provider/java-v0.8.0 \
+  -p "confidence_resolver.wasm*" \
+  --repo spotify/confidence-resolver
+```
+
+This downloads:
+- `confidence_resolver.wasm` - The canonical binary
+- `confidence_resolver.wasm.sha256` - SHA-256 checksum
+
+### 2. Verify the Attestation
+
+GitHub attestations provide cryptographic proof that the WASM was built from specific source code by our CI pipeline:
+
+```bash
+# Verify the attestation (requires gh CLI v2.49.0+)
+gh attestation verify confidence_resolver.wasm \
+  --repo spotify/confidence-resolver
+```
+
+This verifies:
+- ✅ The binary was built by GitHub Actions (not locally or maliciously)
+- ✅ The build came from a specific commit in this repository
+- ✅ The attestation is signed and recorded in Sigstore's transparency log
+
+### 3. Verify the Embedded WASM in Provider Packages
+
+#### Java Provider
+
+Extract and verify the WASM from the JAR:
+
+```bash
+# Download the JAR from Maven Central
+# Extract the WASM
+unzip -p openfeature-provider-local-0.8.0.jar \
+  wasm/confidence_resolver.wasm > extracted.wasm
+
+# Compare with the published WASM
+sha256sum extracted.wasm confidence_resolver.wasm
+```
+
+The checksums should match, proving the JAR contains the attested WASM.
+
+#### JavaScript Provider
+
+```bash
+# Extract from npm package
+npm pack @spotify-confidence/openfeature-provider-local
+tar -xzf spotify-confidence-openfeature-provider-local-*.tgz
+sha256sum package/dist/confidence_resolver.wasm confidence_resolver.wasm
+```
+
+#### Go Provider
+
+The Go provider embeds WASM at compile time. Verify the embedded binary:
+
+```bash
+# In the repository
+sha256sum openfeature-provider/go/confidence/wasm/confidence_resolver.wasm \
+  confidence_resolver.wasm
+```
+
+## Verifying Provider Packages
+
+### Java Provider (JAR)
+
+Java packages are GPG signed and published to Maven Central:
+
+```bash
+# Maven Central automatically verifies GPG signatures
+# You can also verify manually:
+gpg --verify openfeature-provider-local-0.8.0.jar.asc openfeature-provider-local-0.8.0.jar
+```
+
+The critical WASM binary inside the JAR is attested separately (see above).
+
+### JavaScript Provider
+
+JavaScript packages are published to npm with built-in provenance:
+
+```bash
+# View provenance statement
+npm view @spotify-confidence/openfeature-provider-local --json | jq .dist.attestations
+```
+
+## Deterministic Builds
+
+Our builds are designed to be deterministic in CI:
+
+1. **Pinned Rust toolchain**: `rust-toolchain.toml` locks Rust to version 1.90.0
+2. **Docker-based builds**: Isolated, consistent build environment
+3. **Deterministic compiler flags**: LTO, single codegen unit, stripped symbols
+
+### Building Locally
+
+To build the WASM locally:
+
+```bash
+# Using Docker (recommended - ensures correct dependencies)
+docker build --target wasm-rust-guest.artifact --output type=local,dest=. .
+
+# Or using local Rust toolchain (requires wasm32-unknown-unknown target)
+cd wasm/rust-guest
+cargo build --target wasm32-unknown-unknown --profile wasm
+```
+
+**Note**: Local builds should produce identical binaries when using the same Rust toolchain version and Docker environment. The attestation provides cryptographic proof of the build's provenance.
+
+## WASM Synchronization
+
+Different providers handle WASM embedding differently:
+
+- **Go Provider**: WASM is committed to the repository (required for `//go:embed` at compile time)
+  - **CI Validation**: Docker builds automatically validate committed WASM matches the latest build
+  - **Manual Sync**: Maintainers run `make sync-wasm-go` after WASM changes
+  - If validation fails: `❌ ERROR: WASM files are out of sync!` - follow the error message instructions
+
+- **Java and JavaScript Providers**: WASM is NOT committed
+  - WASM is copied from the build artifact during Docker builds
+  - Always uses the current WASM automatically - no manual sync needed
+
+## Security Best Practices for Users
+
+1. **Always verify attestations** for production deployments
+2. **Pin specific versions** in your dependency management
+3. **Review release notes** for security-related changes
+4. **Monitor GitHub Security Advisories** for this repository
+5. **Scan dependencies** regularly using tools like Dependabot or Snyk


### PR DESCRIPTION
## Summary
- Adds comprehensive documentation to SECURITY.md about binary provenance and supply chain security
- Documents how to verify WASM binary attestations
- Provides instructions for verifying provider packages (Java, JavaScript, Go)
- Explains deterministic builds and WASM synchronization

## Context
This PR contains only the documentation changes that describe the provenance implementation. The actual provenance implementation is in a separate PR and should be merged first.

## Test plan
- [ ] Merge the [provenance implementation PR](https://github.com/spotify/confidence-resolver/pull/182)
- [ ] Verify that `gh attestation verify` works with a released WASM binary
- [ ] Verify the documentation instructions are accurate
- [ ] Merge this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)