### PR TITLE
fix: align rust provider component name in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -67,6 +67,7 @@
       "path": "openfeature-provider/rust",
       "release-type": "rust",
       "changelog-path": "CHANGELOG.md",
+      "component": "openfeature-provider/rust",
       "initial-version": "0.1.0",
       "extra-files": ["src/version.rs"]
     }


### PR DESCRIPTION
## Summary
- Add `component` field to rust provider in release-please config to match naming convention used by other providers

This ensures the rust provider shows as `openfeature-provider/rust` in release notes instead of the crate name `spotify-confidence-openfeature-provider-local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)