### PR TITLE
feat: configurable gateway

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,7 @@
 {
-  "rust-analyzer.cargo.target": "wasm32-unknown-unknown",
   "rust-analyzer.cargo.features": [],
   "rust-analyzer.cargo.extraEnv": {
-    "PROTOC":"/opt/homebrew/bin/protoc"
+    "PROTOC": "/opt/homebrew/bin/protoc"
   },
   "protoc": {
     "options": ["-I/${workspaceRoot}/confidence-resolver/protos"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,12 +187,21 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.34"
+version = "1.2.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
 dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -196,6 +227,25 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -238,6 +288,26 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -326,10 +396,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -358,6 +443,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
 
 [[package]]
 name = "fixedbitset"
@@ -391,6 +482,12 @@ name = "fragile"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -515,6 +612,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +647,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -594,6 +716,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -619,7 +742,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -641,9 +763,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -858,6 +982,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,6 +1069,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +1088,12 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -982,7 +1153,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -998,6 +1169,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1050,6 +1231,12 @@ version = "0.6.0"
 dependencies = [
  "rust-guest",
 ]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
 
 [[package]]
 name = "papaya"
@@ -1385,6 +1572,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
@@ -1551,13 +1739,15 @@ checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -1566,14 +1756,13 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
  "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
+ "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -1584,7 +1773,20 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42e2f48018a33d679ee7f477a446b697663a14e91ab0b3a0206792a22dd3aa8"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "thiserror 2.0.16",
+ "tower-service",
 ]
 
 [[package]]
@@ -1660,12 +1862,24 @@ version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1679,11 +1893,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1702,10 +1944,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "seize"
@@ -1846,10 +2129,13 @@ dependencies = [
  "chrono",
  "confidence_resolver",
  "hex 0.4.3",
+ "http",
+ "num_cpus",
  "open-feature",
  "prost 0.12.6",
  "rand 0.9.2",
  "reqwest",
+ "reqwest-middleware",
  "sha2",
  "thiserror 1.0.69",
  "tokio",
@@ -1898,6 +2184,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2071,6 +2378,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tonic-build"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,10 +2498,14 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -2259,6 +2583,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -2404,10 +2738,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
+name = "webpki-root-certs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2429,6 +2763,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2443,8 +2786,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -2482,6 +2825,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2491,12 +2845,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -2524,6 +2905,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -2561,6 +2966,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2573,6 +2984,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2582,6 +2999,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2609,6 +3032,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2618,6 +3047,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2633,6 +3068,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2642,6 +3083,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/openfeature-provider/go/bench/main.go
+++ b/openfeature-provider/go/bench/main.go
@@ -110,7 +110,7 @@ func main() {
 	}
 
 	// Minimal evaluation context; you can extend with attributes to exercise targeting
-	evalCtx := openfeature.FlattenedContext{"targetingKey": "tutorial_visitor", "visitor_id": "tutorial_visitor"}
+	evalCtx := openfeature.FlattenedContext{"targetingKey": "tutorial_visitor", "visitor_id": "tutorial_visitor", "sticky":false}
 
 	// Prepare cancellation on SIGINT/SIGTERM
 	sigCh := make(chan os.Signal, 1)

--- a/openfeature-provider/rust/Cargo.toml
+++ b/openfeature-provider/rust/Cargo.toml
@@ -25,7 +25,9 @@ open-feature = "0.2.7"
 tokio = { version = "1", features = ["rt", "time", "sync", "macros"] }
 
 # HTTP client for state fetching and log sending
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.13.1" }
+reqwest-middleware = "0.5.0"
+http = "1.0.0"
 
 # Cryptography for CDN URL hash
 sha2 = "0.10"
@@ -55,8 +57,13 @@ chrono = { version = "0.4", features = ["clock"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+num_cpus = "1.16"
 
 [[example]]
 name = "demo"
 path = "examples/demo.rs"
+
+[[example]]
+name = "bench"
+path = "examples/bench.rs"

--- a/openfeature-provider/rust/examples/bench.rs
+++ b/openfeature-provider/rust/examples/bench.rs
@@ -1,0 +1,337 @@
+//! Benchmark for the Confidence OpenFeature provider.
+//!
+//! This benchmark is similar to the Go and JS benchmarks in the same repository.
+//!
+//! ## Running
+//!
+//! ```bash
+//! # Against mock server (default)
+//! cargo run --release --example bench -- --mock-addr localhost:8081
+//!
+//! # With custom duration and threads
+//! cargo run --release --example bench -- --duration 60 --threads 4
+//! ```
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use open_feature::{EvaluationContext, OpenFeature, StructValue};
+use spotify_confidence_openfeature_provider_local::{ConfidenceProvider, ProviderOptions};
+use tokio::signal;
+use tokio::sync::broadcast;
+
+// Default configuration
+const DEFAULT_MOCK_ADDR: &str = "http://localhost:8081";
+const DEFAULT_DURATION_SECS: u64 = 30;
+const DEFAULT_WARMUP_SECS: u64 = 5;
+const DEFAULT_FLAG_KEY: &str = "web-sdk-e2e-flag";
+const DEFAULT_CLIENT_SECRET: &str = "ti5Sipq5EluCYRG7I5cdbpWC3xq7JTWv";
+
+struct Args {
+    mock_addr: String,
+    duration_secs: u64,
+    warmup_secs: u64,
+    threads: usize,
+    flag_key: String,
+    client_secret: String,
+}
+
+impl Args {
+    fn parse() -> Self {
+        let mut args = Args {
+            mock_addr: DEFAULT_MOCK_ADDR.to_string(),
+            duration_secs: DEFAULT_DURATION_SECS,
+            warmup_secs: DEFAULT_WARMUP_SECS,
+            threads: num_cpus::get(),
+            flag_key: DEFAULT_FLAG_KEY.to_string(),
+            client_secret: DEFAULT_CLIENT_SECRET.to_string(),
+        };
+
+        let argv: Vec<String> = std::env::args().collect();
+        let mut i = 1;
+        while i < argv.len() {
+            match argv[i].as_str() {
+                "--mock-addr" | "-mock-addr" => {
+                    i += 1;
+                    if i < argv.len() {
+                        args.mock_addr = argv[i].clone();
+                        // Ensure it has a scheme
+                        if !args.mock_addr.starts_with("http://")
+                            && !args.mock_addr.starts_with("https://")
+                        {
+                            args.mock_addr = format!("http://{}", args.mock_addr);
+                        }
+                    }
+                }
+                "--duration" | "-duration" => {
+                    i += 1;
+                    if i < argv.len() {
+                        args.duration_secs = argv[i].parse().unwrap_or(DEFAULT_DURATION_SECS);
+                    }
+                }
+                "--warmup" | "-warmup" => {
+                    i += 1;
+                    if i < argv.len() {
+                        args.warmup_secs = argv[i].parse().unwrap_or(DEFAULT_WARMUP_SECS);
+                    }
+                }
+                "--threads" | "-threads" => {
+                    i += 1;
+                    if i < argv.len() {
+                        args.threads = argv[i].parse().unwrap_or(num_cpus::get());
+                    }
+                }
+                "--flag" | "-flag" => {
+                    i += 1;
+                    if i < argv.len() {
+                        args.flag_key = argv[i].clone();
+                    }
+                }
+                "--client-secret" | "-client-secret" => {
+                    i += 1;
+                    if i < argv.len() {
+                        args.client_secret = argv[i].clone();
+                    }
+                }
+                "--help" | "-h" => {
+                    eprintln!(
+                        "Usage: bench [OPTIONS]
+
+Options:
+  --mock-addr <ADDR>       Mock server address (default: {})
+  --duration <SECS>        Benchmark duration in seconds (default: {})
+  --warmup <SECS>          Warmup duration in seconds (default: {})
+  --threads <N>            Number of concurrent tasks (default: num_cpus)
+  --flag <KEY>             Flag key to evaluate (default: {})
+  --client-secret <SECRET> Client secret (default: {})
+  --help                   Show this help message",
+                        DEFAULT_MOCK_ADDR,
+                        DEFAULT_DURATION_SECS,
+                        DEFAULT_WARMUP_SECS,
+                        DEFAULT_FLAG_KEY,
+                        DEFAULT_CLIENT_SECRET
+                    );
+                    std::process::exit(0);
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+
+        args
+    }
+}
+
+struct Stats {
+    completed: AtomicU64,
+    errors: AtomicU64,
+}
+
+impl Stats {
+    fn new() -> Self {
+        Self {
+            completed: AtomicU64::new(0),
+            errors: AtomicU64::new(0),
+        }
+    }
+
+    fn reset(&self) {
+        self.completed.store(0, Ordering::SeqCst);
+        self.errors.store(0, Ordering::SeqCst);
+    }
+}
+
+async fn run_worker(
+    client: Arc<open_feature::Client>,
+    flag_key: String,
+    context: EvaluationContext,
+    stats: Arc<Stats>,
+    mut shutdown_rx: broadcast::Receiver<()>,
+    abort_on_error: bool,
+) -> bool {
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown_rx.recv() => {
+                return true;
+            }
+            result = client.get_struct_details::<StructValue>(&flag_key, Some(&context), None) => {
+                match result {
+                    Ok(details) => {
+                        stats.completed.fetch_add(1, Ordering::Relaxed);
+                        if details.reason == Some(open_feature::EvaluationReason::Error) {
+                            stats.errors.fetch_add(1, Ordering::Relaxed);
+                            if abort_on_error {
+                                eprintln!("Error during evaluation: {:?}", details);
+                                return false;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        stats.errors.fetch_add(1, Ordering::Relaxed);
+                        if abort_on_error {
+                            eprintln!("Error during evaluation: {:?}", e);
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn run_workers(
+    client: Arc<open_feature::Client>,
+    flag_key: &str,
+    context: &EvaluationContext,
+    num_threads: usize,
+    stats: Arc<Stats>,
+    duration: Duration,
+    abort_on_error: bool,
+) -> bool {
+    let (shutdown_tx, _) = broadcast::channel::<()>(1);
+
+    let mut handles = Vec::with_capacity(num_threads);
+    for _ in 0..num_threads {
+        let client = Arc::clone(&client);
+        let flag_key = flag_key.to_string();
+        let context = context.clone();
+        let stats = Arc::clone(&stats);
+        let shutdown_rx = shutdown_tx.subscribe();
+
+        handles.push(tokio::spawn(async move {
+            run_worker(
+                client,
+                flag_key,
+                context,
+                stats,
+                shutdown_rx,
+                abort_on_error,
+            )
+            .await
+        }));
+    }
+
+    // Wait for duration or SIGINT/SIGTERM
+    tokio::select! {
+        _ = tokio::time::sleep(duration) => {}
+        _ = signal::ctrl_c() => {
+            eprintln!("\nReceived interrupt signal, stopping...");
+        }
+    }
+
+    // Signal all workers to stop
+    drop(shutdown_tx);
+
+    // Wait for all workers
+    let mut success = true;
+    for handle in handles {
+        match handle.await {
+            Ok(worker_success) => {
+                if !worker_success {
+                    success = false;
+                }
+            }
+            Err(e) => {
+                eprintln!("Worker task panicked: {:?}", e);
+                success = false;
+            }
+        }
+    }
+
+    success
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing for debug output
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let args = Args::parse();
+
+    // Create provider options with gateway URL pointing to mock server
+    let options = ProviderOptions::new(&args.client_secret).with_gateway_url(&args.mock_addr);
+
+    // Create the Confidence provider
+    let provider = ConfidenceProvider::new(options)?;
+
+    // Set the provider on the OpenFeature singleton
+    OpenFeature::singleton_mut()
+        .await
+        .set_provider(provider)
+        .await;
+
+    // Create an OpenFeature client
+    let client = Arc::new(OpenFeature::singleton().await.create_client());
+
+    // Create evaluation context
+    let context = EvaluationContext::default()
+        .with_targeting_key("tutorial_visitor")
+        .with_custom_field("visitor_id", "tutorial_visitor")
+        .with_custom_field("sticky", false);
+
+    let stats = Arc::new(Stats::new());
+
+    // Warmup phase
+    if args.warmup_secs > 0 {
+        eprintln!(
+            "Warming up for {} seconds with {} threads...",
+            args.warmup_secs, args.threads
+        );
+        let success = run_workers(
+            Arc::clone(&client),
+            &args.flag_key,
+            &context,
+            args.threads,
+            Arc::clone(&stats),
+            Duration::from_secs(args.warmup_secs),
+            true, // abort on error during warmup
+        )
+        .await;
+
+        if !success || stats.errors.load(Ordering::SeqCst) > 0 {
+            eprintln!("Aborting: error during warmup");
+            std::process::exit(1);
+        }
+
+        stats.reset();
+    }
+
+    // Measurement phase
+    eprintln!(
+        "Starting measurement for {} seconds with {} threads...",
+        args.duration_secs, args.threads
+    );
+
+    let start = Instant::now();
+    run_workers(
+        Arc::clone(&client),
+        &args.flag_key,
+        &context,
+        args.threads,
+        Arc::clone(&stats),
+        Duration::from_secs(args.duration_secs),
+        true, // abort on error
+    )
+    .await;
+    let elapsed = start.elapsed();
+
+    let completed = stats.completed.load(Ordering::SeqCst);
+    let errors = stats.errors.load(Ordering::SeqCst);
+    let qps = completed as f64 / elapsed.as_secs_f64();
+
+    println!(
+        "flag={} threads={} duration={}ms ops={} errors={} throughput={:.0} ops/s",
+        args.flag_key,
+        args.threads,
+        elapsed.as_millis(),
+        completed,
+        errors,
+        qps
+    );
+
+    Ok(())
+}

--- a/openfeature-provider/rust/src/error.rs
+++ b/openfeature-provider/rust/src/error.rs
@@ -56,5 +56,11 @@ impl From<reqwest::Error> for Error {
     }
 }
 
+impl From<reqwest_middleware::Error> for Error {
+    fn from(e: reqwest_middleware::Error) -> Self {
+        Error::Http(e.to_string())
+    }
+}
+
 /// Result type alias for the provider.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/openfeature-provider/rust/src/gateway.rs
+++ b/openfeature-provider/rust/src/gateway.rs
@@ -1,0 +1,88 @@
+use http::{Extensions, HeaderValue};
+use reqwest::{Request, Response, Url};
+use reqwest_middleware::{Middleware, Next, Result};
+
+use crate::Error;
+
+pub struct GatewayMiddleware {
+    gateway: Url,
+}
+
+impl GatewayMiddleware {
+    pub fn from_str(url: &str) -> crate::Result<GatewayMiddleware> {
+        let url = Url::parse(url)
+            .map_err(|e| Error::Configuration(format!("invalid gateway URL: {e}")))?;
+        Ok(GatewayMiddleware { gateway: url })
+    }
+}
+
+/// Error type for gateway middleware failures.
+#[derive(Debug)]
+struct GatewayError(String);
+
+impl std::fmt::Display for GatewayError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "gateway error: {}", self.0)
+    }
+}
+
+impl std::error::Error for GatewayError {}
+
+#[async_trait::async_trait]
+impl Middleware for GatewayMiddleware {
+    async fn handle(
+        &self,
+        mut req: Request,
+        extensions: &mut Extensions,
+        next: Next<'_>,
+    ) -> Result<Response> {
+        let url = req.url_mut();
+
+        // Capture original host for X-Forwarded-Host header
+        let orig_host = url
+            .host_str()
+            .ok_or_else(|| {
+                reqwest_middleware::Error::Middleware(
+                    GatewayError("request URL has no host".into()).into(),
+                )
+            })?
+            .to_string();
+
+        // Rewrite URL to point to gateway
+        url.set_scheme(self.gateway.scheme()).map_err(|()| {
+            reqwest_middleware::Error::Middleware(
+                GatewayError(format!(
+                    "cannot set scheme '{}' on request URL",
+                    self.gateway.scheme()
+                ))
+                .into(),
+            )
+        })?;
+
+        url.set_host(self.gateway.host_str()).map_err(|e| {
+            reqwest_middleware::Error::Middleware(
+                GatewayError(format!("cannot set gateway host: {e}")).into(),
+            )
+        })?;
+
+        url.set_port(self.gateway.port()).map_err(|()| {
+            reqwest_middleware::Error::Middleware(
+                GatewayError(format!(
+                    "cannot set port {:?} on request URL",
+                    self.gateway.port()
+                ))
+                .into(),
+            )
+        })?;
+
+        // Add X-Forwarded-Host header
+        let header_value = HeaderValue::from_str(&orig_host).map_err(|e| {
+            reqwest_middleware::Error::Middleware(
+                GatewayError(format!("invalid host for header: {e}")).into(),
+            )
+        })?;
+        req.headers_mut().insert("x-forwarded-host", header_value);
+
+        next.run(req, extensions).await
+    }
+}

--- a/openfeature-provider/rust/src/lib.rs
+++ b/openfeature-provider/rust/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod error;
+mod gateway;
 pub mod host;
 pub mod logger;
 pub mod materialization;
@@ -9,7 +10,7 @@ mod version;
 #[cfg(test)]
 pub mod test_utils;
 
-pub use error::Error;
+pub use error::{Error, Result};
 pub use materialization::{MaterializationStore, ReadOpType, ReadResultType, WriteOp};
 pub use provider::{ConfidenceProvider, MaterializationStoreConfig, ProviderOptions};
 pub use version::VERSION;

--- a/wasm/rust-guest/rust-analyzer.toml
+++ b/wasm/rust-guest/rust-analyzer.toml
@@ -1,0 +1,2 @@
+[cargo]
+target = "wasm32-unknown-unknown"


### PR DESCRIPTION
Adds a gateway_url option to the Rust provider which can be used to route all traffic through a proxy/mock-server. Also adds a similar benchmark test like the other providers. ...and it makes some small fixes to the mock-server used for benchmark.