### PR TITLE
test(java): stabilize flaky CDN failure recovery tests

### DIFF
--- a/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/ThreadLocalSwapWasmResolverApi.java
+++ b/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/ThreadLocalSwapWasmResolverApi.java
@@ -48,7 +48,9 @@ class ThreadLocalSwapWasmResolverApi implements ResolverApi {
     // Pre-create instances based on CPU core count for optimal performance
     final var defaultNumberOfInstances = Runtime.getRuntime().availableProcessors();
 
-    return Optional.ofNullable(System.getenv("CONFIDENCE_NUMBER_OF_WASM_INSTANCES"))
+    // Check system property first (allows tests to override), then env var
+    return Optional.ofNullable(System.getProperty("CONFIDENCE_NUMBER_OF_WASM_INSTANCES"))
+        .or(() -> Optional.ofNullable(System.getenv("CONFIDENCE_NUMBER_OF_WASM_INSTANCES")))
         .map(Integer::parseInt)
         .orElse(defaultNumberOfInstances);
   }


### PR DESCRIPTION
## Summary
- Add system property fallback for `CONFIDENCE_NUMBER_OF_WASM_INSTANCES` to allow tests to override WASM instance count
- Use single WASM instance in CDN failure tests to speed up initialization
- Add synchronization latch to prevent race condition where CDN is enabled before retry loop starts
- Increase timeout with polling interval for more reliable detection

## Test plan
- [x] Run `OpenFeatureLocalResolveProviderCdnFailureTest` multiple times locally
- [ ] Verify CI passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)