### PR TITLE
chore(go): exclude embedded wasm from release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -53,7 +53,8 @@
       "include-component-in-tag": true,
       "component": "openfeature-provider/go",
       "tag-separator": "/",
-      "extra-files": ["confidence/version.go"]
+      "extra-files": ["confidence/version.go"],
+      "exclude-paths": ["confidence/internal/local_resolver/assets/confidence_resolver.wasm"]
     },
     "openfeature-provider/ruby": {
       "release-type": "ruby",


### PR DESCRIPTION
## Summary
- Exclude the embedded wasm file from triggering releases for the Go OpenFeature provider
- The wasm file is updated on changes to `wasm/confidence-resolver` and should not be considered a change to the Go provider itself

## Test plan
- [ ] Verify release-please correctly ignores changes to the wasm file

🤖 Generated with [Claude Code](https://claude.com/claude-code)