### PR TITLE
feat(python): add PyPI publishing workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,7 @@ jobs:
       js_provider_release_created: ${{ steps.releasemanifest.outputs['openfeature-provider/js--release_created'] }}
       ruby_provider_release_created: ${{ steps.releasemanifest.outputs['openfeature-provider/ruby--release_created'] }}
       rust_provider_release_created: ${{ steps.releasemanifest.outputs['openfeature-provider/rust--release_created'] }}
+      python_provider_release_created: ${{ steps.releasemanifest.outputs['openfeature-provider/python--release_created'] }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -262,3 +263,34 @@ jobs:
       - name: Publish to crates.io
         working-directory: openfeature-provider/rust
         run: cargo publish
+
+  publish-python-provider-release:
+    needs: release
+    runs-on: ubuntu-latest
+    environment: deployment
+    permissions:
+      id-token: write  # Required for PyPI OIDC trusted publishing
+      contents: read
+    if: ${{ needs.release.outputs.python_provider_release_created == 'true' }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and extract package with Docker
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: openfeature-provider-python.artifact
+          outputs: type=local,dest=./artifacts
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cache:main
+
+      - name: List artifacts
+        run: ls -la ./artifacts/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ./artifacts/

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -8,5 +8,5 @@
   "openfeature-provider/go": "0.8.0",
   "openfeature-provider/ruby": "0.1.1",
   "openfeature-provider/rust": "0.2.1",
-  "openfeature-provider/python": "0.0.1"
+  "openfeature-provider/python": "0.2.1"
 }

--- a/openfeature-provider/python/README.md
+++ b/openfeature-provider/python/README.md
@@ -5,7 +5,7 @@ This is the Python OpenFeature provider for [Confidence](https://confidence.spot
 ## Installation
 
 ```bash
-pip install confidence-local-openfeature-provider
+pip install confidence-openfeature-provider
 ```
 
 ## Usage

--- a/openfeature-provider/python/pyproject.toml
+++ b/openfeature-provider/python/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "confidence-local-openfeature-provider"
-version = "0.0.1"
+name = "confidence-openfeature-provider"
+version = "0.2.1"
 description = "Confidence OpenFeature provider for local flag resolution using WebAssembly"
 readme = "README.md"
 license = "Apache-2.0"

--- a/openfeature-provider/python/src/confidence/version.py
+++ b/openfeature-provider/python/src/confidence/version.py
@@ -1,3 +1,3 @@
 """Version information for the Confidence OpenFeature provider."""
 
-__version__ = "0.0.1"  # x-release-please-version
+__version__ = "0.2.1"  # x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -76,7 +76,7 @@
       "path": "openfeature-provider/python",
       "release-type": "rust",
       "changelog-path": "CHANGELOG.md",
-      "extra-files": ["pyproject.toml", "src/confidence_openfeature/version.py"]
+      "extra-files": ["pyproject.toml", "src/confidence/version.py"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `publish-python-provider-release` job to release-please workflow
- Build with Docker to ensure WASM file is correctly included in the package
- Use PyPI trusted publishing (OIDC) for secure uploads
- Rename package to `confidence-openfeature-provider`
- Set version to 0.2.1
- Fix version file path in release-please config

## PyPI Package

This PR re-uses the existing PyPI package: https://pypi.org/project/confidence-openfeature-provider/

The last version (0.2.0) was published in May 2024. This new implementation starts at version 0.2.1.

PyPI trusted publishing has been configured.

🤖 Generated with [Claude Code](https://claude.ai/code)