### PR TITLE
fix(python): disable Docker provenance for PyPI publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -286,6 +286,7 @@ jobs:
           target: openfeature-provider-python.artifact
           outputs: type=local,dest=./artifacts
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cache:main
+          provenance: false
 
       - name: List artifacts
         run: ls -la ./artifacts/


### PR DESCRIPTION
## Summary

Disable Docker BuildKit provenance generation when building the Python package artifact.

The `provenance.json` file generated by BuildKit is not a valid Python distribution and causes the PyPI publish step to fail with:

```
InvalidDistribution: Unknown distribution format: 'provenance.json'
```

🤖 Generated with [Claude Code](https://claude.ai/code)