### PR TITLE
fix(python): update minimum Python version to 3.10

### DIFF
--- a/openfeature-provider/python/README.md
+++ b/openfeature-provider/python/README.md
@@ -14,7 +14,7 @@ A high-performance OpenFeature provider for [Confidence](https://confidence.spot
 
 ## Requirements
 
-- Python 3.9+
+- Python 3.10+
 - OpenFeature SDK 0.8.0+
 
 ## Installation

--- a/openfeature-provider/python/pyproject.toml
+++ b/openfeature-provider/python/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "confidence-openfeature-provider"
-version = "0.2.1"
+version = "0.3.0" # x-release-please-version
 description = "Confidence OpenFeature provider for local flag resolution using WebAssembly"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
     { name = "Spotify", email = "confidence@spotify.com" }
 ]
@@ -18,7 +18,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -67,7 +66,7 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 warn_unused_configs = true
 warn_redundant_casts = true
 strict_equality = true
@@ -95,7 +94,7 @@ disable_error_code = ["attr-defined", "name-defined", "union-attr", "operator", 
 
 [tool.ruff]
 line-length = 88
-target-version = "py39"
+target-version = "py310"
 exclude = [".venv", ".git", "*_pb2.py", "*_pb2_grpc.py"]
 
 [tool.ruff.lint]


### PR DESCRIPTION
## Summary

Update minimum Python version from 3.9 to 3.10.

OpenFeature Python SDK is dropping Python 3.9 support in the upcoming 0.9.0 release ([PR #554](https://github.com/open-feature/python-sdk/pull/554)). This update aligns our provider with the upcoming SDK requirements.

## Changes

- `requires-python`: `>=3.9` → `>=3.10`
- Remove Python 3.9 from classifiers
- Update mypy `python_version` to 3.10
- Update ruff `target-version` to py310

🤖 Generated with [Claude Code](https://claude.ai/code)