### PR TITLE
fix(java): exclude .proto files from JAR

### DIFF
--- a/openfeature-provider/java/pom.xml
+++ b/openfeature-provider/java/pom.xml
@@ -239,6 +239,8 @@
           <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
           <pluginId>grpc-java</pluginId>
           <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+          <!-- Don't bundle .proto files in the JAR – consumers use the generated Java API -->
+          <attachProtoSources>false</attachProtoSources>
         </configuration>
         <executions>
           <!-- Compile the Confidence API protos and WASM interop messages from this repo to satisfy imports and stubs -->
@@ -551,6 +553,8 @@
                     <exclude>META-INF/*.DSA</exclude>
                     <exclude>META-INF/*.RSA</exclude>
                     <exclude>module-info.class</exclude>
+                    <!-- Exclude .proto files from shaded deps to avoid classpath collisions -->
+                    <exclude>**/*.proto</exclude>
                   </excludes>
                 </filter>
               </filters>


### PR DESCRIPTION
## Summary
- The `protobuf-maven-plugin` defaults `attachProtoSources` to `true`, bundling `.proto` source files into the JAR
- This causes classpath collisions when consumers also depend on JARs that ship the same proto paths
- Set `attachProtoSources` to `false` and add `**/*.proto` exclusion in the shade plugin filter to strip protos from shaded dependencies as well

## Test plan
- [x] Verified JAR contains zero `.proto` files after the change
- [x] Verified compiled `.class` files and gRPC stubs are still present
- [ ] Downstream integration test to confirm collision is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)