### PR TITLE
ci: add CodeQL workflow with manual Java build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   security-events: write
+  packages: read
 
 jobs:
   analyze:
@@ -19,6 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - language: actions
+            build-mode: none
           - language: java-kotlin
             build-mode: manual
           - language: go
@@ -28,6 +31,8 @@ jobs:
           - language: python
             build-mode: none
           - language: ruby
+            build-mode: none
+          - language: rust
             build-mode: none
 
     steps:
@@ -48,8 +53,10 @@ jobs:
           build-mode: ${{ matrix.build-mode }}
 
       - name: Build Java provider
-        if: matrix.language == 'java-kotlin'
+        if: matrix.build-mode == 'manual'
         run: mvn -B compile -f openfeature-provider/java/pom.xml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Adds a dedicated CodeQL workflow that compiles the Java provider before analysis
- Uses `build-mode: manual` with explicit `mvn compile` since the project is nested under `openfeature-provider/java/`
- Fixes low analysis quality warnings from the default CodeQL setup (low call target resolution and type coverage)

## Test plan
- [ ] Verify the CodeQL workflow runs successfully on this PR
- [ ] Check that the analysis quality warnings are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)