### PR TITLE
perf(java): pre-compile WASM module once and reuse across instances

### DIFF
--- a/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/WasmResolveApi.java
+++ b/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/WasmResolveApi.java
@@ -1,12 +1,11 @@
 package com.spotify.confidence.sdk;
 
-import com.dylibso.chicory.compiler.MachineFactoryCompiler;
 import com.dylibso.chicory.runtime.ExportFunction;
 import com.dylibso.chicory.runtime.ImportFunction;
 import com.dylibso.chicory.runtime.ImportValues;
 import com.dylibso.chicory.runtime.Instance;
+import com.dylibso.chicory.runtime.Machine;
 import com.dylibso.chicory.runtime.Memory;
-import com.dylibso.chicory.wasm.Parser;
 import com.dylibso.chicory.wasm.WasmModule;
 import com.dylibso.chicory.wasm.types.FunctionType;
 import com.dylibso.chicory.wasm.types.ValType;
@@ -21,8 +20,6 @@ import com.spotify.confidence.sdk.flags.resolver.v1.ResolveWithStickyRequest;
 import com.spotify.confidence.sdk.flags.resolver.v1.ResolveWithStickyResponse;
 import com.spotify.confidence.sdk.flags.resolver.v1.WriteFlagLogsRequest;
 import com.spotify.confidence.sdk.wasm.Messages;
-import java.io.IOException;
-import java.io.InputStream;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -47,41 +44,33 @@ class WasmResolveApi {
   private final ExportFunction wasmMsgGuestResolveWithSticky;
   private final ReadWriteLock wasmLock = new ReentrantReadWriteLock();
 
-  public WasmResolveApi(WasmFlagLogger flagLogger) {
+  public WasmResolveApi(
+      WasmFlagLogger flagLogger, WasmModule module, Function<Instance, Machine> machineFactory) {
     this.writeFlagLogs = flagLogger;
-    try (InputStream wasmStream =
-        getClass().getClassLoader().getResourceAsStream("wasm/confidence_resolver.wasm")) {
-      if (wasmStream == null) {
-        throw new RuntimeException("Could not find confidence_resolver.wasm in resources");
-      }
-      final WasmModule module = Parser.parse(wasmStream);
-      instance =
-          Instance.builder(module)
-              .withImportValues(
-                  ImportValues.builder()
-                      .addFunction(
-                          createImportFunction(
-                              "current_time", Messages.Void::parseFrom, this::currentTime))
-                      .addFunction(
-                          createImportFunction("log_message", LogMessage::parseFrom, this::log))
-                      .addFunction(
-                          new ImportFunction(
-                              "wasm_msg",
-                              "wasm_msg_current_thread_id",
-                              FunctionType.of(List.of(), List.of(ValType.I32)),
-                              this::currentThreadId))
-                      .build())
-              .withMachineFactory(MachineFactoryCompiler::compile)
-              .build();
-      wasmMsgAlloc = instance.export("wasm_msg_alloc");
-      wasmMsgFree = instance.export("wasm_msg_free");
-      wasmMsgGuestSetResolverState = instance.export("wasm_msg_guest_set_resolver_state");
-      wasmMsgFlushLogs = instance.export("wasm_msg_guest_flush_logs");
-      wasmMsgGuestResolve = instance.export("wasm_msg_guest_resolve");
-      wasmMsgGuestResolveWithSticky = instance.export("wasm_msg_guest_resolve_with_sticky");
-    } catch (IOException e) {
-      throw new RuntimeException("Failed to load WASM module", e);
-    }
+    instance =
+        Instance.builder(module)
+            .withImportValues(
+                ImportValues.builder()
+                    .addFunction(
+                        createImportFunction(
+                            "current_time", Messages.Void::parseFrom, this::currentTime))
+                    .addFunction(
+                        createImportFunction("log_message", LogMessage::parseFrom, this::log))
+                    .addFunction(
+                        new ImportFunction(
+                            "wasm_msg",
+                            "wasm_msg_current_thread_id",
+                            FunctionType.of(List.of(), List.of(ValType.I32)),
+                            this::currentThreadId))
+                    .build())
+            .withMachineFactory(machineFactory)
+            .build();
+    wasmMsgAlloc = instance.export("wasm_msg_alloc");
+    wasmMsgFree = instance.export("wasm_msg_free");
+    wasmMsgGuestSetResolverState = instance.export("wasm_msg_guest_set_resolver_state");
+    wasmMsgFlushLogs = instance.export("wasm_msg_guest_flush_logs");
+    wasmMsgGuestResolve = instance.export("wasm_msg_guest_resolve");
+    wasmMsgGuestResolveWithSticky = instance.export("wasm_msg_guest_resolve_with_sticky");
   }
 
   private Message log(LogMessage message) {


### PR DESCRIPTION
## Summary
- Pre-compile the WASM module once in `SwapWasmResolverApi` constructor using `MachineFactoryCompiler.compile(WasmModule)` and reuse the compiled machine factory across all `WasmResolveApi` instances.
- Previously, every `updateStateAndFlushLogs` call created a new `WasmResolveApi`, triggering full AOT WASM-to-JVM bytecode compilation each time via `MachineFactoryCompiler::compile(Instance)`.

## Test plan
- [x] `mvn compile` passes
- [x] Verified all test failures are pre-existing (missing deps, missing env vars)
- [ ] Verify in staging that state updates no longer cause CPU spikes from WASM recompilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)