### PR TITLE
fix(js): increase state fetch stall timeout to 1s

### DIFF
--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.test.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.test.ts
@@ -129,7 +129,7 @@ describe('state update scheduling', () => {
     expect(mockedWasmResolver.setResolverState).toHaveBeenCalledTimes(1);
   });
   it('retries state download with backoff and stall-timeout', async () => {
-    let chunkDelay = 600;
+    let chunkDelay = 1500;
     net.cdn.state.handler = req => {
       const body = new ReadableStream<Uint8Array>({
         async start(controller) {
@@ -142,10 +142,10 @@ describe('state update scheduling', () => {
       });
       return new Response(body);
     };
-    // Decrease chunkDelay after 2.5s so next retry succeeds
+    // Decrease chunkDelay after a few retries so next retry succeeds
     setTimeout(() => {
       chunkDelay = 100;
-    }, 2500);
+    }, 6000);
 
     await advanceTimersUntil(provider.updateState());
     expect(net.cdn.state.calls).toBeGreaterThan(1);

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
@@ -81,7 +81,7 @@ export class ConfidenceServerProviderLocal implements Provider {
               baseInterval: 500,
               maxInterval: this.stateUpdateInterval,
             }),
-            withStallTimeout(500),
+            withStallTimeout(1 * TimeUnit.SECOND),
           ],
           'https://resolver.confidence.dev/*': [
             withRouter({


### PR DESCRIPTION
## Summary
- Increase the default state fetch stall timeout from 500ms to 1s in the JS local resolve provider

## Test plan
- [ ] Verify the stall timeout is correctly set to 1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)