### PR TITLE
fix: match full rollout rules when targeting key is missing

### DIFF
--- a/confidence-resolver/test-payloads/resolver-spec/tests.json
+++ b/confidence-resolver/test-payloads/resolver-spec/tests.json
@@ -171,18 +171,6 @@
           }
         ],
         "expectError": null
-      },
-      "rust": {
-        "resolvedFlags": [
-          {
-            "flag": "flags/full-rollout-flag",
-            "reason": "RESOLVE_REASON_NO_SEGMENT_MATCH",
-            "variant": "",
-            "value": null,
-            "shouldApply": false
-          }
-        ],
-        "expectError": null
       }
     }
   },
@@ -862,18 +850,6 @@
               "enabled": true
             },
             "shouldApply": true
-          }
-        ],
-        "expectError": null
-      },
-      "rust": {
-        "resolvedFlags": [
-          {
-            "flag": "flags/full-rollout-flag",
-            "reason": "RESOLVE_REASON_NO_SEGMENT_MATCH",
-            "variant": "",
-            "value": null,
-            "shouldApply": false
           }
         ],
         "expectError": null
@@ -1765,18 +1741,6 @@
               "enabled": true
             },
             "shouldApply": true
-          }
-        ],
-        "expectError": null
-      },
-      "rust": {
-        "resolvedFlags": [
-          {
-            "flag": "flags/mat-write-no-unit-flag",
-            "reason": "RESOLVE_REASON_NO_SEGMENT_MATCH",
-            "variant": "",
-            "value": null,
-            "shouldApply": false
           }
         ],
         "expectError": null


### PR DESCRIPTION
When a rule has an empty targetingKeySelector and the evaluation context has no targeting_key, the Rust resolver was unconditionally skipping the rule. For full rollouts (100% bucket coverage with a single assignment), the flag should still resolve to MATCH - no targeting key is needed since there's no randomization to do.

This change aligns the Rust resolver behavior with the Java resolver:

- When targetingKeySelector is blank, we don't require a targeting key for full rollouts (100% bucket coverage with single assignment)
- Added `has_only_one_full_variant` helper to check for full rollouts
- For segment matching without a unit, only proceed if selector is blank AND it's a full rollout AND bitset (if any) is "ALL"
- For assignment bucketing, full rollouts use the first assignment directly without hash-based bucketing

Fixes: spotify/confidence-resolver#294