### PR TITLE
ci: build Rust crates with Docker for publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -210,24 +210,21 @@ jobs:
       - name: Checkout release tag
         uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Write crates.io token to file
+        run: |
+          echo "${{ secrets.CRATES_IO_TOKEN }}" > /tmp/crates_io_token.txt
+
+      - name: Publish confidence-resolver with Docker
+        uses: docker/build-push-action@v6
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Install protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cargo login
-        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
-
-      - name: Publish to crates.io
-        working-directory: confidence-resolver
-        run: cargo publish
+          context: .
+          target: confidence-resolver.publish
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cache:main
+          secret-files: |
+            crates_io_token=/tmp/crates_io_token.txt
 
   publish-rust-provider-release:
     needs: [release, publish-confidence-resolver-release]
@@ -241,28 +238,25 @@ jobs:
       - name: Checkout release tag
         uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-      - name: Install protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cargo login
-        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Write crates.io token to file
+        run: |
+          echo "${{ secrets.CRATES_IO_TOKEN }}" > /tmp/crates_io_token.txt
 
       - name: Wait for crates.io index update
         if: ${{ needs.publish-confidence-resolver-release.result == 'success' }}
         run: sleep 30
 
-      - name: Publish to crates.io
-        working-directory: openfeature-provider/rust
-        run: cargo publish
+      - name: Publish Rust provider with Docker
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: openfeature-provider-rust.publish
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cache:main
+          secret-files: |
+            crates_io_token=/tmp/crates_io_token.txt
 
   publish-python-provider-release:
     needs: release

--- a/Dockerfile
+++ b/Dockerfile
@@ -607,6 +607,26 @@ WORKDIR /workspace/openfeature-provider/rust
 RUN make build
 
 # ==============================================================================
+# Publish confidence-resolver to crates.io
+# ==============================================================================
+FROM openfeature-provider-rust.build AS confidence-resolver.publish
+
+WORKDIR /workspace/confidence-resolver
+RUN --mount=type=secret,id=crates_io_token \
+    cargo login $(cat /run/secrets/crates_io_token) && \
+    cargo publish
+
+# ==============================================================================
+# Publish OpenFeature Provider (Rust) to crates.io
+# ==============================================================================
+FROM openfeature-provider-rust.build AS openfeature-provider-rust.publish
+
+WORKDIR /workspace/openfeature-provider/rust
+RUN --mount=type=secret,id=crates_io_token \
+    cargo login $(cat /run/secrets/crates_io_token) && \
+    cargo publish
+
+# ==============================================================================
 # OpenFeature Provider (Java) - Build and test
 # ==============================================================================
 FROM eclipse-temurin:17-jdk AS openfeature-provider-java-base


### PR DESCRIPTION
## Summary
- Add `confidence-resolver.publish` and `openfeature-provider-rust.publish` Docker targets for crates.io publishing
- Update `release-please.yml` to use Docker builds instead of installing toolchain/protoc directly on the runner
- Aligns Rust publish jobs with how Java, JS, Ruby, and Python already publish via Docker, preventing version drift

## Test plan
- [ ] Trigger a confidence-resolver release and verify it publishes to crates.io
- [ ] Trigger a rust provider release and verify it publishes to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)