### PR TITLE
chore: add arm64 platform to deployer image build

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -90,7 +90,7 @@ jobs:
           push: true
           build-args: |
             COMMIT_SHA=${{ github.sha }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cache:main
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -88,7 +88,7 @@ jobs:
           push: true
           build-args: |
             COMMIT_SHA=${{ github.sha }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cache:main
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Adds `linux/arm64` to the deployer image build platforms so it works natively on Apple Silicon Macs without `--platform linux/amd64` emulation.

Closes #300

## Test plan
- [x] Verify CI passes
- [ ] On next `confidence-cloudflare-resolver` release, confirm the pushed image has both `linux/amd64` and `linux/arm64` manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)