### PR TITLE
test: add spec test for self-referencing segment

### DIFF
--- a/confidence-resolver/src/resolver_spec_tests.rs
+++ b/confidence-resolver/src/resolver_spec_tests.rs
@@ -488,6 +488,7 @@ spec_test!(bitset_no_unit);
 // Nested / circular segments
 spec_test!(nested_segment_match);
 spec_test!(circular_segment_dependency);
+spec_test!(self_referencing_segment);
 
 // Variant / assignment
 spec_test!(fallthrough_then_match);

--- a/confidence-resolver/test-payloads/resolver-spec/state.json
+++ b/confidence-resolver/test-payloads/resolver-spec/state.json
@@ -509,6 +509,32 @@
         }
       ]
     },
+    "flags/self-ref-segment-flag": {
+      "name": "flags/self-ref-segment-flag",
+      "state": "ACTIVE",
+      "clients": ["clients/test-client"],
+      "variants": [
+        { "name": "on", "value": { "enabled": true } }
+      ],
+      "rules": [
+        {
+          "name": "flags/self-ref-segment-flag/rules/rule1",
+          "segment": "segments/self-referencing",
+          "enabled": true,
+          "targetingKeySelector": "targeting_key",
+          "assignmentSpec": {
+            "bucketCount": 1000,
+            "assignments": [
+              {
+                "assignmentId": "a1",
+                "variant": { "variant": "on" },
+                "bucketRanges": [{ "lower": 0, "upper": 1000 }]
+              }
+            ]
+          }
+        }
+      ]
+    },
     "flags/fallthrough-flag": {
       "name": "flags/fallthrough-flag",
       "state": "ACTIVE",
@@ -2240,6 +2266,20 @@
         "expression": { "ref": "c1" }
       }
     },
+    "segments/self-referencing": {
+      "name": "segments/self-referencing",
+      "state": "OK",
+      "targeting": {
+        "criteria": {
+          "c1": {
+            "segment": {
+              "segment": "segments/self-referencing"
+            }
+          }
+        },
+        "expression": { "ref": "c1" }
+      }
+    },
     "segments/any-set-inner": {
       "name": "segments/any-set-inner",
       "state": "OK",
@@ -2696,6 +2736,7 @@
     "segments/nested-parent": "ALL",
     "segments/circular-a": "ALL",
     "segments/circular-b": "ALL",
+    "segments/self-referencing": "ALL",
     "segments/any-set-inner": "ALL",
     "segments/any-starts-with-inner": "ALL",
     "segments/any-ends-with-inner": "ALL",

--- a/confidence-resolver/test-payloads/resolver-spec/tests.json
+++ b/confidence-resolver/test-payloads/resolver-spec/tests.json
@@ -717,6 +717,32 @@
     }
   },
   {
+    "name": "self_referencing_segment",
+    "resolveRequest": {
+      "flags": ["flags/self-ref-segment-flag"],
+      "evaluationContext": { "targeting_key": "user1", "country": "SE" },
+      "clientSecret": "test-secret"
+    },
+    "expectedResult": {
+      "general": {
+        "resolvedFlags": [
+          {
+            "flag": "flags/self-ref-segment-flag",
+            "reason": "RESOLVE_REASON_NO_SEGMENT_MATCH",
+            "variant": "",
+            "value": null,
+            "shouldApply": false
+          }
+        ],
+        "expectError": null
+      },
+      "rust": {
+        "resolvedFlags": [],
+        "expectError": "InternalError"
+      }
+    }
+  },
+  {
     "name": "fallthrough_then_match",
     "resolveRequest": {
       "flags": [


### PR DESCRIPTION
## Summary
- Adds a spec test for a segment that references itself directly (as opposed to the existing A->B->A circular test)
- Verifies the resolver detects the cycle and handles it gracefully

## Test plan
- [x] `cargo test -p confidence_resolver self_referencing_segment` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)