### PR TITLE
fix: free WASM guest request allocation in host functions

### DIFF
--- a/openfeature-provider/go/confidence/internal/local_resolver/wasm.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/wasm.go
@@ -2,15 +2,13 @@ package local_resolver
 
 import (
 	"context"
+	_ "embed"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
 	"sync/atomic"
-	"time"
-
-	_ "embed"
 
 	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/wasm"
 
@@ -144,29 +142,34 @@ type WasmResolverFactory struct {
 
 var _ LocalResolverFactory = (*WasmResolverFactory)(nil)
 
+func consumeRequest(inst api.Module, ptr uint32) []byte {
+	if ptr == 0 {
+		return nil
+	}
+	data := consume(inst, ptr)
+	req := &wasm.Request{}
+	mustUnmarshal(data, req)
+	return req.GetData()
+}
+
+func transferResponseSuccess(inst api.Module, data []byte) uint32 {
+	resp := &wasm.Response{Result: &wasm.Response_Data{Data: data}}
+	return transfer(inst, mustMarshal(resp))
+}
+
+func transferResponseError(inst api.Module, errMsg string) uint32 {
+	resp := &wasm.Response{Result: &wasm.Response_Error{Error: errMsg}}
+	return transfer(inst, mustMarshal(resp))
+}
+
 func NewWasmResolverFactory(logSink LogSink) LocalResolverFactory {
 	ctx := context.Background()
 	runtime := wazero.NewRuntime(ctx)
 	_, err := runtime.NewHostModuleBuilder("wasm_msg").
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module, ptr uint32) uint32 {
-			// Free the request allocated by the WASM guest
-			if ptr != 0 {
-				consume(mod, ptr)
-			}
-
-			// Return current timestamp
-			now := time.Now()
-			timestamp := timestamppb.New(now)
-
-			// Create response wrapper
-			response := &wasm.Response{
-				Result: &wasm.Response_Data{
-					Data: mustMarshal(timestamp),
-				},
-			}
-
-			return transfer(mod, mustMarshal(response))
+			consumeRequest(mod, ptr)
+			return transferResponseSuccess(mod, mustMarshal(timestamppb.Now()))
 		}).
 		Export("wasm_msg_host_current_time").
 		Instantiate(ctx)

--- a/openfeature-provider/go/confidence/internal/local_resolver/wasm.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/wasm.go
@@ -150,6 +150,11 @@ func NewWasmResolverFactory(logSink LogSink) LocalResolverFactory {
 	_, err := runtime.NewHostModuleBuilder("wasm_msg").
 		NewFunctionBuilder().
 		WithFunc(func(ctx context.Context, mod api.Module, ptr uint32) uint32 {
+			// Free the request allocated by the WASM guest
+			if ptr != 0 {
+				consume(mod, ptr)
+			}
+
 			// Return current timestamp
 			now := time.Now()
 			timestamp := timestamppb.New(now)

--- a/openfeature-provider/go/confidence/internal/local_resolver/wasm_memory_test.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/wasm_memory_test.go
@@ -1,0 +1,67 @@
+package local_resolver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/wasm"
+	tu "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/testutil"
+)
+
+// TestWasmMemoryStableOnRepeatedResolveCalls verifies that WASM linear memory
+// does not grow unboundedly when resolving flags repeatedly. Each resolve_flags
+// call triggers a current_time() host call from the guest. If the host function
+// does not free the guest's request allocation, memory leaks accumulate and
+// eventually force WASM memory.grow.
+func TestWasmMemoryStableOnRepeatedResolveCalls(t *testing.T) {
+	factory := NewWasmResolverFactory(NoOpLogSink)
+	defer factory.Close(context.Background())
+
+	resolver := factory.New()
+	defer resolver.Close(context.Background())
+
+	wasmResolver := resolver.(*WasmResolver)
+
+	testState := tu.LoadTestResolverState(t)
+	testAcctID := tu.LoadTestAccountID(t)
+
+	if err := wasmResolver.SetResolverState(&wasm.SetResolverStateRequest{
+		State:     testState,
+		AccountId: testAcctID,
+	}); err != nil {
+		t.Fatalf("Failed to set resolver state: %v", err)
+	}
+
+	request := tu.CreateResolveProcessRequest(tu.CreateTutorialFeatureRequest())
+
+	// Warm up: let allocator settling and one-time growth complete.
+	for i := 0; i < 50_000; i++ {
+		if _, err := wasmResolver.ResolveProcess(request); err != nil {
+			t.Fatalf("ResolveProcess failed during warmup: %v", err)
+		}
+		if i%1000 == 0 {
+			wasmResolver.FlushAllLogs()
+		}
+	}
+
+	memBefore := wasmResolver.instance.Memory().Size()
+
+	// Run resolves. Each call triggers current_time() in the guest which
+	// allocates a request in WASM memory. A leak here causes linear growth.
+	iterations := 50_000
+	for i := 0; i < iterations; i++ {
+		if _, err := wasmResolver.ResolveProcess(request); err != nil {
+			t.Fatalf("ResolveProcess failed at iteration %d: %v", i, err)
+		}
+		if i%1000 == 0 {
+			wasmResolver.FlushAllLogs()
+		}
+	}
+
+	memAfter := wasmResolver.instance.Memory().Size()
+
+	if memAfter > memBefore {
+		t.Errorf("WASM memory grew from %d to %d bytes (%d bytes / %d pages) after %d resolve calls — indicates a leak in host function memory management",
+			memBefore, memAfter, memAfter-memBefore, (memAfter-memBefore)/65536, iterations)
+	}
+}

--- a/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/WasmMemoryLeakTest.java
+++ b/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/WasmMemoryLeakTest.java
@@ -1,0 +1,77 @@
+package com.spotify.confidence.sdk;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.dylibso.chicory.runtime.Instance;
+import com.google.protobuf.Struct;
+import com.google.protobuf.util.Structs;
+import com.google.protobuf.util.Values;
+import com.spotify.confidence.sdk.flags.resolver.v1.ResolveFlagsRequest;
+import com.spotify.confidence.sdk.flags.resolver.v1.ResolveProcessRequest;
+import java.lang.reflect.Field;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for WASM memory leak in host functions. Each resolve_flags call triggers a
+ * current_time() host call which allocates a request in WASM memory. If the host doesn't free it,
+ * memory leaks ~20 bytes per call and eventually forces memory.grow.
+ */
+class WasmMemoryLeakTest {
+
+  private static int getWasmMemoryPages(WasmLocalResolver resolver) {
+    try {
+      Field instanceField = WasmLocalResolver.class.getDeclaredField("instance");
+      instanceField.setAccessible(true);
+      Instance instance = (Instance) instanceField.get(resolver);
+      return instance.memory().pages();
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Failed to access WASM memory via reflection", e);
+    }
+  }
+
+  @Test
+  void wasmMemoryStableOnRepeatedResolveCalls() {
+    WasmLocalResolver resolver = new WasmLocalResolver(request -> {});
+    resolver.setResolverState(ResolveTest.exampleStateBytes, "account", null);
+
+    ResolveProcessRequest request =
+        ResolveProcessRequest.newBuilder()
+            .setDeferredMaterializations(
+                ResolveFlagsRequest.newBuilder()
+                    .addAllFlags(List.of("flags/flag-1"))
+                    .setClientSecret(ResolveTest.secret.getSecret())
+                    .setEvaluationContext(
+                        Structs.of(
+                            "targeting_key",
+                            Values.of("user-123"),
+                            "bar",
+                            Values.of(Struct.newBuilder().build())))
+                    .setApply(true)
+                    .build())
+            .build();
+
+    // Warm up to settle one-time allocations
+    for (int i = 0; i < 50_000; i++) {
+      resolver.resolveProcess(request).toCompletableFuture().join();
+      if (i % 1000 == 0) resolver.flushAllLogs();
+    }
+
+    int pagesBefore = getWasmMemoryPages(resolver);
+
+    for (int i = 0; i < 50_000; i++) {
+      resolver.resolveProcess(request).toCompletableFuture().join();
+      if (i % 1000 == 0) resolver.flushAllLogs();
+    }
+
+    int pagesAfter = getWasmMemoryPages(resolver);
+
+    assertEquals(
+        pagesBefore,
+        pagesAfter,
+        String.format(
+            "WASM memory grew from %d to %d pages (%d bytes leaked) — "
+                + "host function is not freeing guest request allocations",
+            pagesBefore, pagesAfter, (pagesAfter - pagesBefore) * 65536L));
+  }
+}

--- a/openfeature-provider/js/src/WasmResolver.memory.test.ts
+++ b/openfeature-provider/js/src/WasmResolver.memory.test.ts
@@ -24,7 +24,7 @@ const RESOLVE_REQUEST: ResolveProcessRequest = {
 const SET_STATE_REQUEST = { state: stateBytes, accountId: 'confidence-test' };
 
 describe('wasm memory stability', () => {
-  it('should not leak memory on repeated resolve calls', () => {
+  it('should not leak memory on repeated resolve calls', { timeout: 30_000 }, () => {
     const resolver = new UnsafeWasmResolver(module);
     resolver.setResolverState(SET_STATE_REQUEST);
 

--- a/openfeature-provider/js/src/WasmResolver.memory.test.ts
+++ b/openfeature-provider/js/src/WasmResolver.memory.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { UnsafeWasmResolver } from './WasmResolver';
+import { readFileSync } from 'node:fs';
+import { ResolveProcessRequest } from './proto/confidence/wasm/wasm_api';
+
+const moduleBytes = readFileSync(__dirname + '/../../../wasm/confidence_resolver.wasm');
+const stateBytes = readFileSync(__dirname + '/../../../wasm/resolver_state.pb');
+
+const module = new WebAssembly.Module(moduleBytes);
+const CLIENT_SECRET = 'mkjJruAATQWjeY7foFIWfVAcBWnci2YF';
+
+const RESOLVE_REQUEST: ResolveProcessRequest = {
+  deferredMaterializations: {
+    flags: ['flags/tutorial-feature'],
+    clientSecret: CLIENT_SECRET,
+    apply: true,
+    evaluationContext: {
+      targeting_key: 'tutorial_visitor',
+      visitor_id: 'tutorial_visitor',
+    },
+  },
+};
+
+const SET_STATE_REQUEST = { state: stateBytes, accountId: 'confidence-test' };
+
+describe('wasm memory stability', () => {
+  it('should not leak memory on repeated resolve calls', () => {
+    const resolver = new UnsafeWasmResolver(module);
+    resolver.setResolverState(SET_STATE_REQUEST);
+
+    // Warm up to settle one-time allocations
+    for (let i = 0; i < 50_000; i++) {
+      resolver.resolveProcess(RESOLVE_REQUEST);
+      if (i % 1000 === 0) resolver.flushLogs();
+    }
+
+    const memBefore = (resolver as any).exports.memory.buffer.byteLength;
+
+    for (let i = 0; i < 50_000; i++) {
+      resolver.resolveProcess(RESOLVE_REQUEST);
+      if (i % 1000 === 0) resolver.flushLogs();
+    }
+
+    const memAfter = (resolver as any).exports.memory.buffer.byteLength;
+
+    expect(memAfter).toBe(memBefore);
+  });
+});

--- a/openfeature-provider/js/src/WasmResolver.ts
+++ b/openfeature-provider/js/src/WasmResolver.ts
@@ -59,7 +59,11 @@ export class UnsafeWasmResolver implements LocalResolver {
   constructor(module: WebAssembly.Module) {
     const imports = {
       wasm_msg: {
-        wasm_msg_host_current_time: () => {
+        wasm_msg_host_current_time: (requestPtr: number) => {
+          // Free the request allocated by the WASM guest
+          if (requestPtr !== 0) {
+            this.free(requestPtr);
+          }
           const epochMs = performance.timeOrigin + performance.now();
           const seconds = Math.floor(epochMs / 1000);
           const nanos = Math.round((epochMs - seconds * 1000) * 1_000_000);

--- a/openfeature-provider/js/src/WasmResolver.ts
+++ b/openfeature-provider/js/src/WasmResolver.ts
@@ -60,15 +60,11 @@ export class UnsafeWasmResolver implements LocalResolver {
     const imports = {
       wasm_msg: {
         wasm_msg_host_current_time: (requestPtr: number) => {
-          // Free the request allocated by the WASM guest
-          if (requestPtr !== 0) {
-            this.free(requestPtr);
-          }
+          this.consumeRequest(requestPtr);
           const epochMs = performance.timeOrigin + performance.now();
           const seconds = Math.floor(epochMs / 1000);
           const nanos = Math.round((epochMs - seconds * 1000) * 1_000_000);
-          const ptr = this.transferRequest({ seconds, nanos }, Timestamp);
-          return ptr;
+          return this.transferResponseSuccess({ seconds, nanos }, Timestamp);
         },
       },
     };
@@ -123,6 +119,21 @@ export class UnsafeWasmResolver implements LocalResolver {
     const reqPtr = this.transferRequest({ instance }, PrometheusSnapshotRequest);
     const resPtr = this.exports.wasm_msg_guest_prometheus_snapshot(reqPtr);
     return this.consumeResponse(resPtr, PrometheusSnapshotResponse).text;
+  }
+
+  private consumeRequest(ptr: number): Uint8Array | undefined {
+    if (ptr === 0) return undefined;
+    const { data }: Request = this.consume(ptr, Request);
+    return data;
+  }
+
+  private transferResponseSuccess<T>(value: T, codec: Codec<T>): number {
+    const data = codec.encode(value).finish();
+    return this.transfer({ data }, Response);
+  }
+
+  private transferResponseError(error: string): number {
+    return this.transfer({ error }, Response);
   }
 
   private transferRequest<T>(value: T, codec: Codec<T>): number {

--- a/openfeature-provider/python/src/confidence/wasm_resolver.py
+++ b/openfeature-provider/python/src/confidence/wasm_resolver.py
@@ -74,27 +74,11 @@ class WasmResolver:
         """Register host functions that can be called from WASM."""
 
         def current_time(ptr: int) -> int:
-            """Host function to return current timestamp."""
-            # Free the request allocated by the WASM guest
-            if ptr != 0:
-                self._wasm_msg_free(self._store, ptr)
-            try:
-                # Create timestamp from current time
-                now = datetime.now()
-                timestamp = Timestamp()
-                timestamp.FromDatetime(now)
-
-                # Create response wrapper with timestamp data
-                response = messages_pb2.Response()
-                response.data = timestamp.SerializeToString()
-
-                # Transfer response to WASM memory
-                return self._transfer(response.SerializeToString())
-            except Exception as e:
-                # Return error response
-                error_response = messages_pb2.Response()
-                error_response.error = str(e)
-                return self._transfer(error_response.SerializeToString())
+            self._consume_request(ptr)
+            now = datetime.now()
+            timestamp = Timestamp()
+            timestamp.FromDatetime(now)
+            return self._transfer_response_success(timestamp.SerializeToString())
 
         # Create function type: takes one i32 parameter, returns one i32
         func_type = FuncType([ValType.i32()], [ValType.i32()])
@@ -244,6 +228,27 @@ class WasmResolver:
         self._memory.write(self._store, data, ptr)
 
         return ptr
+
+    def _consume_request(self, addr: int) -> bytes:
+        """Consume a wasm-msg Request envelope from WASM memory (read + free)."""
+        if addr == 0:
+            return b""
+        data = self._consume(addr)
+        request = messages_pb2.Request()
+        request.ParseFromString(data)
+        return request.data
+
+    def _transfer_response_success(self, data: bytes) -> int:
+        """Wrap data in a wasm-msg Response and transfer to WASM memory."""
+        response = messages_pb2.Response()
+        response.data = data
+        return self._transfer(response.SerializeToString())
+
+    def _transfer_response_error(self, error: str) -> int:
+        """Wrap an error in a wasm-msg Response and transfer to WASM memory."""
+        response = messages_pb2.Response()
+        response.error = error
+        return self._transfer(response.SerializeToString())
 
     def _consume_response(
         self, addr: int, target: Optional[protobuf_message.Message]

--- a/openfeature-provider/python/src/confidence/wasm_resolver.py
+++ b/openfeature-provider/python/src/confidence/wasm_resolver.py
@@ -75,6 +75,9 @@ class WasmResolver:
 
         def current_time(ptr: int) -> int:
             """Host function to return current timestamp."""
+            # Free the request allocated by the WASM guest
+            if ptr != 0:
+                self._wasm_msg_free(self._store, ptr)
             try:
                 # Create timestamp from current time
                 now = datetime.now()

--- a/openfeature-provider/python/tests/test_wasm_resolver.py
+++ b/openfeature-provider/python/tests/test_wasm_resolver.py
@@ -162,6 +162,18 @@ class TestFlushAssigned:
 class TestMemoryManagement:
     """Test memory allocation and deallocation."""
 
+    @staticmethod
+    def _build_request(client_secret: str) -> wasm_api_pb2.ResolveProcessRequest:
+        resolve_request = api_pb2.ResolveFlagsRequest()
+        resolve_request.flags.append(TEST_FLAG_NAME)
+        resolve_request.client_secret = client_secret
+        evaluation_context = struct_pb2.Struct()
+        evaluation_context.fields["targeting_key"].string_value = "user-123"
+        resolve_request.evaluation_context.CopyFrom(evaluation_context)
+        request = wasm_api_pb2.ResolveProcessRequest()
+        request.deferred_materializations.CopyFrom(resolve_request)
+        return request
+
     def test_multiple_resolves_dont_leak_memory(
         self,
         wasm_bytes: bytes,
@@ -169,22 +181,33 @@ class TestMemoryManagement:
         test_account_id: str,
         test_client_secret: str,
     ) -> None:
-        """Multiple resolves don't cause memory issues."""
+        """WASM memory must not grow on repeated resolves.
+
+        Each resolve_flags call triggers a current_time() host call which
+        allocates a request in WASM memory. If the host doesn't free it,
+        memory leaks ~20 bytes per call and eventually forces memory.grow.
+        """
         resolver = WasmResolver(wasm_bytes)
         resolver.set_resolver_state(test_resolver_state, test_account_id)
+        request = self._build_request(test_client_secret)
 
-        for i in range(100):
-            resolve_request = api_pb2.ResolveFlagsRequest()
-            resolve_request.flags.append(TEST_FLAG_NAME)
-            resolve_request.client_secret = test_client_secret
-            evaluation_context = struct_pb2.Struct()
-            evaluation_context.fields["targeting_key"].string_value = f"user-{i}"
-            resolve_request.evaluation_context.CopyFrom(evaluation_context)
-
-            request = wasm_api_pb2.ResolveProcessRequest()
-            request.deferred_materializations.CopyFrom(resolve_request)
+        # Warm up to settle one-time allocations
+        for i in range(50_000):
             resolver.resolve_process(request)
+            if i % 1000 == 0:
+                resolver.flush_logs()
 
-        # Should complete without issues
-        logs = resolver.flush_logs()
-        assert isinstance(logs, bytes)
+        pages_before = resolver._memory.size(resolver._store)
+
+        for i in range(50_000):
+            resolver.resolve_process(request)
+            if i % 1000 == 0:
+                resolver.flush_logs()
+
+        pages_after = resolver._memory.size(resolver._store)
+
+        assert pages_after == pages_before, (
+            f"WASM memory grew from {pages_before} to {pages_after} pages "
+            f"({(pages_after - pages_before) * 65536} bytes leaked) — "
+            f"host function is not freeing guest request allocations"
+        )


### PR DESCRIPTION
## Summary

- Fix memory leak where `wasm_msg_host_current_time` host function never frees the request pointer allocated by the WASM guest
- Each `resolve_flags`/`apply_flags` call leaked ~20 bytes of WASM linear memory (which can only grow, never shrink)
- Over days of continuous operation this caused unbounded memory growth (observed 50MB → 300MB over a week)
- Go, JS, and Python host functions now free the incoming request pointer. Java was already correct.
- Add WASM memory regression tests for all four providers

## Test plan

- [x] Go: `TestWasmMemoryStableOnRepeatedResolveCalls` — 50k resolves, zero memory growth
- [x] JS: `wasm memory stability` — 50k resolves, zero memory growth
- [x] Python: `test_multiple_resolves_dont_leak_memory` — 50k resolves, zero memory growth
- [x] Java: `wasmMemoryStableOnRepeatedResolveCalls` — 50k resolves, zero memory growth

🤖 Generated with [Claude Code](https://claude.com/claude-code)