### PR TITLE
chore: bump aws-lc-rs 1.15.3 → 1.16.2 and aws-lc-sys 0.36.0 → 0.39.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.3"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e84ce723ab67259cfeb9877c6a639ee9eb7a27b28123abd71db7f0d5d0cc9d86"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.36.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a442ece363113bd4bd4c8b18977a7798dd4d3c3383f34fb61936960e8f4ad8"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
## Summary
- Bump `aws-lc-rs` from 1.15.3 to 1.16.2 and `aws-lc-sys` from 0.36.0 to 0.39.1
- Lockfile-only change, no `Cargo.toml` modifications needed
- Only affects the native Rust provider (`openfeature-provider/rust/`)

## Security
Resolves **5 high-severity** Dependabot alerts on `aws-lc-sys`:

| Alert | Severity | Advisory | Fixed in |
|-------|----------|----------|----------|
| #29 | HIGH | [GHSA-vw5v-4f2q-w9xf](https://github.com/advisories/GHSA-vw5v-4f2q-w9xf) — PKCS7_verify Certificate Chain Validation Bypass | 0.38.0 |
| #30 | HIGH | [GHSA-65p9-r9h6-22vj](https://github.com/advisories/GHSA-65p9-r9h6-22vj) — Timing Side-Channel in AES-CCM Tag Verification | 0.38.0 |
| #31 | HIGH | [GHSA-hfpc-8r3f-gw53](https://github.com/advisories/GHSA-hfpc-8r3f-gw53) — PKCS7_verify Signature Validation Bypass | 0.38.0 |
| #39 | HIGH | [GHSA-394x-vwmw-crm3](https://github.com/advisories/GHSA-394x-vwmw-crm3) — X.509 Name Constraints Bypass via Wildcard/Unicode CN | 0.39.0 |
| #40 | HIGH | [GHSA-9f94-5g5w-gf6r](https://github.com/advisories/GHSA-9f94-5g5w-gf6r) — CRL Distribution Point Scope Check Logic Error | 0.39.0 |

## Test plan
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)