### PR TITLE
chore: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -32,4 +32,4 @@ On `confidence-cloudflare-resolver` release, the deployer Docker image is built 
 
 ## PR Lint (`lint-pr-name.yaml`)
 
-PR titles must follow **conventional commits** (`feat:`, `fix:`, `chore:`, etc.). Enforced via `amannn/action-semantic-pull-request@v5`. Posts a sticky comment on the PR explaining the error if validation fails.
+PR titles must follow **conventional commits** (`feat:`, `fix:`, `chore:`, etc.). Enforced via `amannn/action-semantic-pull-request@v6`. Posts a sticky comment on the PR explaining the error if validation fails.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,14 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
         if: github.event_name == 'push'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -31,7 +31,7 @@ jobs:
 
       - name: Build and test everything (PR)
         if: github.event_name != 'push'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/arm64
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build and test everything (Push - updates cache)
         if: github.event_name == 'push'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/arm64

--- a/.github/workflows/lint-pr-name.yaml
+++ b/.github/workflows/lint-pr-name.yaml
@@ -15,12 +15,12 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@v6
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@v3
         # When the previous steps fails, the workflow would stop. By adding this
         # condition you can continue the execution with the populated error message.
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
@@ -39,7 +39,7 @@ jobs:
 
       # Delete a previous comment when the issue has been resolved
       - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:   
           header: pr-title-lint-error
           delete: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@ jobs:
       python_provider_release_created: ${{ steps.releasemanifest.outputs['openfeature-provider/python--release_created'] }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -51,7 +51,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Extract confidence-cloudflare-resolver version and tag
         id: extract_ccr_version
@@ -61,13 +61,13 @@ jobs:
           echo "CCR_TAG_NAME=confidence-cloudflare-resolver-v$VERSION" >> $GITHUB_ENV
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/confidence-cloudflare-deployer
           tags: |
@@ -83,7 +83,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push deployer image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: confidence-cloudflare-resolver.deployer
@@ -102,10 +102,10 @@ jobs:
     if: ${{ needs.release.outputs.java_provider_release_created == 'true' }}
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Construct Maven settings file
         run: |
@@ -131,7 +131,7 @@ jobs:
           echo "${{ secrets.SIGN_KEY_PASS }}" > /tmp/gpg_pass.txt
 
       - name: Publish Java package with Docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: openfeature-provider-java.publish
@@ -151,13 +151,13 @@ jobs:
     if: ${{ needs.release.outputs.js_provider_release_created == 'true' }}
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and extract package tarball with Docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: openfeature-provider-js.artifact
@@ -165,7 +165,7 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cache:main
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
@@ -185,17 +185,17 @@ jobs:
     if: ${{ needs.release.outputs.ruby_provider_release_created == 'true' }}
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Write RubyGems API key to file
         run: |
           echo "${{ secrets.RUBYGEM_API_KEY }}" > /tmp/rubygem_api_key.txt
 
       - name: Publish Ruby gem with Docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: openfeature-provider-ruby.publish
@@ -210,17 +210,17 @@ jobs:
     if: ${{ needs.release.outputs.confidence_resolver_release_created == 'true' }}
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Write crates.io token to file
         run: |
           echo "${{ secrets.CRATES_IO_TOKEN }}" > /tmp/crates_io_token.txt
 
       - name: Publish confidence-resolver with Docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: confidence-resolver.publish
@@ -238,10 +238,10 @@ jobs:
       (needs.publish-confidence-resolver-release.result == 'success' || needs.publish-confidence-resolver-release.result == 'skipped')
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Write crates.io token to file
         run: |
@@ -252,7 +252,7 @@ jobs:
         run: sleep 30
 
       - name: Publish Rust provider with Docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: openfeature-provider-rust.publish
@@ -270,13 +270,13 @@ jobs:
     if: ${{ needs.release.outputs.python_provider_release_created == 'true' }}
     steps:
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and extract package with Docker
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: openfeature-provider-python.artifact


### PR DESCRIPTION
## Summary
- Update all GitHub Actions to versions that use the Node.js 24 runtime, addressing the [Node.js 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) (forced Node 24 default starting June 2, 2026; Node 20 removal September 16, 2026).
- `googleapis/release-please-action` stays at v4 — no v5 available yet ([tracking issue](https://github.com/googleapis/release-please-action/issues/1162)).
- `pypa/gh-action-pypi-publish@release/v1` is a composite action (no Node runtime); rolling tag is actively maintained, no v2 exists — left untouched.

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `docker/build-push-action` | v6 | v7 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/metadata-action` | v5 | v6 |
| `amannn/action-semantic-pull-request` | v5 | v6 |
| `marocchino/sticky-pull-request-comment` | v2 | v3 |

## Test plan
- [ ] CI passes on this PR
- [ ] Verify no breaking changes in action inputs/outputs (confirmed via changelog review — none of our used inputs were removed or renamed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)