### PR TITLE
feat(cloudflare): add WORKER_NAME_PREFIX for custom worker naming

### DIFF
--- a/confidence-cloudflare-resolver/deployer/README.md
+++ b/confidence-cloudflare-resolver/deployer/README.md
@@ -62,6 +62,7 @@ The deployer automatically detects:
 | `RESOLVE_TOKEN_ENCRYPTION_KEY`       | AES-128 key (base64 encoded) used to encrypt resolve tokens when `apply=false`. Not needed since the resolver defaults `apply` to `true`          |
 | `FORCE_DEPLOY`                       | Force re-deploy regardless of state changes                                                                                                       |
 | `NO_DEPLOY`                          | Build only, skip deployment                                                                                                                       |
+| `WORKER_NAME_PREFIX`                 | Prefix for the worker name. If set, the worker deploys as `<prefix>-confidence-cloudflare-resolver` instead of `confidence-cloudflare-resolver`  |
 
 ## Service Binding vs HTTP Calls
 

--- a/confidence-cloudflare-resolver/deployer/script.sh
+++ b/confidence-cloudflare-resolver/deployer/script.sh
@@ -13,6 +13,7 @@ CONFIDENCE_RESOLVER_STATE_URL=${CONFIDENCE_RESOLVER_STATE_URL:=}
 CONFIDENCE_CLIENT_SECRET=${CONFIDENCE_CLIENT_SECRET:=}
 NO_DEPLOY=${NO_DEPLOY:=}
 FORCE_DEPLOY=${FORCE_DEPLOY:=}
+WORKER_NAME_PREFIX=${WORKER_NAME_PREFIX:=}
 
 # CDN base URL for fetching resolver state
 CDN_BASE_URL="https://confidence-resolver-state-cdn.spotifycdn.com"
@@ -70,8 +71,13 @@ if test -z "$CONFIDENCE_RESOLVER_STATE_URL"; then
     echo "📦 Using CDN URL for state: ${CDN_BASE_URL}/<sha256>"
 fi
 
-# Worker name from wrangler.toml
-WORKER_NAME="confidence-cloudflare-resolver"
+# Worker name - prepend prefix if provided
+if [ -n "$WORKER_NAME_PREFIX" ]; then
+    WORKER_NAME="${WORKER_NAME_PREFIX}-confidence-cloudflare-resolver"
+    echo "🏷️ Using prefixed worker name: $WORKER_NAME"
+else
+    WORKER_NAME="confidence-cloudflare-resolver"
+fi
 
 # Auto-detect Cloudflare resolver URL from workers subdomain
 CLOUDFLARE_RESOLVER_URL=""
@@ -246,6 +252,12 @@ if [ -n "$CLOUDFLARE_ACCOUNT_ID" ]; then
     mv "$tmpfile" wrangler.toml
 else
     echo "⚠️ CLOUDFLARE_ACCOUNT_ID environment variable is not set. This is required if the CloudFlare API token is of type Account, while User tokens with the correct permissions don't need this env variable set"
+fi
+
+# Update worker name in wrangler.toml if using prefix
+if [ -n "$WORKER_NAME_PREFIX" ]; then
+    sed -i.tmp "s/^name = .*/name = \"$WORKER_NAME\"/" wrangler.toml
+    echo "✅ Updated worker name to \"$WORKER_NAME\" in wrangler.toml"
 fi
 
 # Prepare ALLOWED_ORIGIN for TOML (escape quotes and backslashes)


### PR DESCRIPTION
## Summary
- Add `WORKER_NAME_PREFIX` environment variable to the Cloudflare deployer
- When set, the worker deploys as `<prefix>-confidence-cloudflare-resolver` instead of the default `confidence-cloudflare-resolver`
- Enables deploying multiple resolver instances to the same Cloudflare account

## Test plan
- [ ] Deploy with `WORKER_NAME_PREFIX=myteam` and verify worker name is `myteam-confidence-cloudflare-resolver`
- [ ] Deploy without prefix and verify worker name remains `confidence-cloudflare-resolver`

🤖 Generated with [Claude Code](https://claude.com/claude-code)