### PR TITLE
feat(cloudflare): auto-create queue and prefix queue names

### DIFF
--- a/confidence-cloudflare-resolver/deployer/README.md
+++ b/confidence-cloudflare-resolver/deployer/README.md
@@ -29,13 +29,7 @@ A pre-built image is also available at `ghcr.io/spotify/confidence-cloudflare-de
 
 ## Usage
 
-On the first deploy, create the required Cloudflare Queue:
-
-```bash
-CLOUDFLARE_API_TOKEN='your-cloudflare-api-token' npx wrangler queues create flag-logs-queue
-```
-
-Then run the deployer with your credentials:
+Run the deployer with your credentials:
 
 ```bash
 docker run -it \
@@ -44,11 +38,12 @@ docker run -it \
     ghcr.io/spotify/confidence-cloudflare-deployer:latest
 ```
 
-The deployer automatically detects:
+The deployer automatically:
 
-* **Cloudflare account ID** from your API token
-* **Resolver state** from Confidence CDN
-* **Existing deployment** to avoid unnecessary re-deploys
+* **Detects Cloudflare account ID** from your API token
+* **Creates the queue** (`flag-logs-queue`) if it doesn't exist
+* **Fetches resolver state** from Confidence CDN
+* **Skips deployment** if state hasn't changed (using ETags)
 
 > **Note:** The deployer does not poll for changes. Each run fetches the current state from Confidence, deploys the Worker if the state has changed, and then exits. To keep the Worker up to date, run the deployer on a schedule (for example, via a cron job) or trigger it when flag rules or targeting changes are made in Confidence.
 
@@ -62,7 +57,7 @@ The deployer automatically detects:
 | `RESOLVE_TOKEN_ENCRYPTION_KEY`       | AES-128 key (base64 encoded) used to encrypt resolve tokens when `apply=false`. Not needed since the resolver defaults `apply` to `true`          |
 | `FORCE_DEPLOY`                       | Force re-deploy regardless of state changes                                                                                                       |
 | `NO_DEPLOY`                          | Build only, skip deployment                                                                                                                       |
-| `WORKER_NAME_PREFIX`                 | Prefix for the worker name. If set, the worker deploys as `<prefix>-confidence-cloudflare-resolver` instead of `confidence-cloudflare-resolver`  |
+| `WORKER_NAME_PREFIX`                 | Prefix for worker and queue names. Deploys as `<prefix>-confidence-cloudflare-resolver` with queue `<prefix>-flag-logs-queue` (auto-created)     |
 
 ## Service Binding vs HTTP Calls
 

--- a/confidence-cloudflare-resolver/deployer/script.sh
+++ b/confidence-cloudflare-resolver/deployer/script.sh
@@ -254,10 +254,52 @@ else
     echo "⚠️ CLOUDFLARE_ACCOUNT_ID environment variable is not set. This is required if the CloudFlare API token is of type Account, while User tokens with the correct permissions don't need this env variable set"
 fi
 
-# Update worker name in wrangler.toml if using prefix
+# Determine queue name based on prefix
+if [ -n "$WORKER_NAME_PREFIX" ]; then
+    QUEUE_NAME="${WORKER_NAME_PREFIX}-flag-logs-queue"
+else
+    QUEUE_NAME="flag-logs-queue"
+fi
+
+# Create queue if it doesn't exist
+echo "🔍 Checking if queue '$QUEUE_NAME' exists..."
+QUEUE_CHECK=$(curl -sS -w "%{http_code}" \
+    -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+    "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/queues?name=${QUEUE_NAME}")
+QUEUE_STATUS="${QUEUE_CHECK: -3}"
+QUEUE_BODY="${QUEUE_CHECK%???}"
+
+if [ "$QUEUE_STATUS" = "200" ]; then
+    QUEUE_COUNT=$(printf "%s" "$QUEUE_BODY" | jq -r '.result | length')
+    if [ "$QUEUE_COUNT" = "0" ]; then
+        echo "📦 Queue '$QUEUE_NAME' not found, creating..."
+        CREATE_RESP=$(curl -sS -w "%{http_code}" -X POST \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            -d "{\"queue_name\": \"${QUEUE_NAME}\"}" \
+            "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/queues")
+        CREATE_STATUS="${CREATE_RESP: -3}"
+        if [ "$CREATE_STATUS" = "200" ] || [ "$CREATE_STATUS" = "201" ]; then
+            echo "✅ Queue '$QUEUE_NAME' created successfully"
+        else
+            echo "❌ Failed to create queue (HTTP $CREATE_STATUS)"
+            echo "$CREATE_RESP"
+            exit 1
+        fi
+    else
+        echo "✅ Queue '$QUEUE_NAME' already exists"
+    fi
+else
+    echo "⚠️ Could not check queue status (HTTP $QUEUE_STATUS)"
+fi
+
+# Update worker name and queue name in wrangler.toml if using prefix
 if [ -n "$WORKER_NAME_PREFIX" ]; then
     sed -i.tmp "s/^name = .*/name = \"$WORKER_NAME\"/" wrangler.toml
+    # Update queue name in both producer and consumer sections
+    sed -i.tmp "s/queue = \"flag-logs-queue\"/queue = \"$QUEUE_NAME\"/g" wrangler.toml
     echo "✅ Updated worker name to \"$WORKER_NAME\" in wrangler.toml"
+    echo "✅ Updated queue name to \"$QUEUE_NAME\" in wrangler.toml"
 fi
 
 # Prepare ALLOWED_ORIGIN for TOML (escape quotes and backslashes)


### PR DESCRIPTION
## Summary
- Automatically create the flag-logs queue if it doesn't exist (no more manual `wrangler queues create` step)
- When `WORKER_NAME_PREFIX` is set, also prefix the queue name (e.g., `staging-flag-logs-queue`)
- Each prefixed deployment gets its own isolated queue, ensuring logs are consumed with the correct client secret

## Changes
- **script.sh**: Add queue existence check and auto-creation via Cloudflare API
- **script.sh**: Update queue name in wrangler.toml when using prefix
- **README.md**: Remove manual queue creation step, update docs

## Test plan
- [ ] Deploy without prefix - should auto-create `flag-logs-queue`
- [ ] Deploy with `WORKER_NAME_PREFIX=staging` - should auto-create `staging-flag-logs-queue`
- [ ] Verify logs are sent to the correct queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)