### PR TITLE
fix(java): don't recreate WASM instance on thread interruption

### DIFF
--- a/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProvider.java
+++ b/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProvider.java
@@ -203,8 +203,12 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
 
     assignLogExecutor.scheduleAtFixedRate(
         () -> {
-          if (initialized) {
-            resolver.flushAssignLogs();
+          try {
+            if (initialized) {
+              resolver.flushAssignLogs();
+            }
+          } catch (RuntimeException e) {
+            log.error("Failed to flush assign logs", e);
           }
         },
         ASSIGN_LOG_FLUSH_INTERVAL.toMillis(),
@@ -225,24 +229,28 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
 
     flagsFetcherExecutor.schedule(
         () -> {
-          stateProvider.reload();
-          resolverStateProtobuf.set(stateProvider.provide());
-          accountIdRef.set(stateProvider.accountId());
+          try {
+            stateProvider.reload();
+            resolverStateProtobuf.set(stateProvider.provide());
+            accountIdRef.set(stateProvider.accountId());
 
-          if (!accountIdRef.get().isEmpty()) {
-            if (!initialized) {
-              resolver.setResolverState(resolverStateProtobuf.get(), accountIdRef.get(), SDK);
-              initialized = true;
-              this.state.set(ProviderState.READY);
-              log.info("Provider recovered and is now READY");
-            } else {
-              // State refresh + full log flush
-              resolver.setResolverState(resolverStateProtobuf.get(), accountIdRef.get(), SDK);
-              resolver.flushAllLogs();
+            if (!accountIdRef.get().isEmpty()) {
+              if (!initialized) {
+                resolver.setResolverState(resolverStateProtobuf.get(), accountIdRef.get(), SDK);
+                initialized = true;
+                this.state.set(ProviderState.READY);
+                log.info("Provider recovered and is now READY");
+              } else {
+                // State refresh + full log flush
+                resolver.setResolverState(resolverStateProtobuf.get(), accountIdRef.get(), SDK);
+                resolver.flushAllLogs();
+              }
             }
+          } catch (RuntimeException e) {
+            log.error("State refresh failed", e);
+          } finally {
+            scheduleStateRefresh(resolverStateProtobuf, accountIdRef, pollIntervalSeconds);
           }
-
-          scheduleStateRefresh(resolverStateProtobuf, accountIdRef, pollIntervalSeconds);
         },
         delaySeconds,
         TimeUnit.SECONDS);

--- a/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/PooledResolver.java
+++ b/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/PooledResolver.java
@@ -84,7 +84,14 @@ class PooledResolver implements LocalResolver {
 
   @Override
   public void close() {
-    maintenance(LocalResolver::close);
+    maintenance(
+        lr -> {
+          try {
+            lr.close();
+          } catch (RuntimeException e) {
+            logger.error("Failed to close resolver", e);
+          }
+        });
   }
 
   @Override
@@ -131,8 +138,6 @@ class PooledResolver implements LocalResolver {
       slot.rwLock.writeLock().lock();
       try {
         fn.accept(slot.resolver);
-      } catch (RuntimeException e) {
-        logger.error("Maintenance operation failed on slot {}", i, e);
       } finally {
         slot.rwLock.writeLock().unlock();
       }

--- a/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/RecoveringResolver.java
+++ b/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/RecoveringResolver.java
@@ -1,5 +1,6 @@
 package com.spotify.confidence.sdk;
 
+import com.dylibso.chicory.runtime.ChicoryInterruptedException;
 import com.dylibso.chicory.wasm.ChicoryException;
 import com.spotify.confidence.sdk.flags.resolver.v1.ApplyFlagsRequest;
 import com.spotify.confidence.sdk.flags.resolver.v1.RegisterResolveRequest;
@@ -64,6 +65,10 @@ class RecoveringResolver implements LocalResolver {
   }
 
   private void handleFailure(String opName, ChicoryException e) {
+    if (e instanceof ChicoryInterruptedException) {
+      logger.debug("Resolver interrupted during {}, not recreating", opName);
+      throw e;
+    }
     if (broken.compareAndSet(false, true)) {
       logger.warn(
           "Resolver failed during {} ({}), starting background recreation",

--- a/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/RecoveringResolverTest.java
+++ b/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/RecoveringResolverTest.java
@@ -1,0 +1,62 @@
+package com.spotify.confidence.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.dylibso.chicory.runtime.ChicoryInterruptedException;
+import com.dylibso.chicory.wasm.ChicoryException;
+import com.spotify.confidence.sdk.flags.resolver.v1.Sdk;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class RecoveringResolverTest {
+
+  private static final byte[] STATE = new byte[] {1, 2, 3};
+  private static final String ACCOUNT_ID = "account";
+  private static final Sdk SDK = Sdk.getDefaultInstance();
+
+  @Test
+  void chicoryExceptionTriggersRecreation() throws Exception {
+    final LocalResolver failing = mock(LocalResolver.class);
+    doThrow(new ChicoryException("wasm trap")).when(failing).setResolverState(any(), any(), any());
+
+    final LocalResolver replacement = mock(LocalResolver.class);
+    final AtomicInteger factoryCalls = new AtomicInteger();
+    final RecoveringResolver recovering =
+        new RecoveringResolver(
+            () -> {
+              int call = factoryCalls.incrementAndGet();
+              return call == 1 ? failing : replacement;
+            });
+
+    assertThatThrownBy(() -> recovering.setResolverState(STATE, ACCOUNT_ID, SDK))
+        .isInstanceOf(ChicoryException.class);
+
+    Thread.sleep(200);
+    assertThat(factoryCalls.get()).isEqualTo(2);
+  }
+
+  @Test
+  void interruptedExceptionDoesNotTriggerRecreation() throws Exception {
+    final LocalResolver failing = mock(LocalResolver.class);
+    doThrow(new ChicoryInterruptedException("Thread interrupted"))
+        .when(failing)
+        .setResolverState(any(), any(), any());
+
+    final AtomicInteger factoryCalls = new AtomicInteger();
+    final RecoveringResolver recovering =
+        new RecoveringResolver(
+            () -> {
+              factoryCalls.incrementAndGet();
+              return failing;
+            });
+
+    assertThatThrownBy(() -> recovering.setResolverState(STATE, ACCOUNT_ID, SDK))
+        .isInstanceOf(ChicoryInterruptedException.class);
+
+    Thread.sleep(200);
+    assertThat(factoryCalls.get()).isEqualTo(1);
+  }
+}


### PR DESCRIPTION
## Summary

- `RecoveringResolver` now distinguishes `ChicoryInterruptedException` from
  other `ChicoryException` types — interrupts are rethrown without triggering
  background WASM instance recreation, since the instance isn't actually broken.
- `PooledResolver.maintenance()` no longer catches `RuntimeException`. Errors
  propagate to callers instead of being silently swallowed. The `close()` path
  retains its own catch to ensure all slots are cleaned up.
- Scheduler lambdas in `OpenFeatureLocalResolveProvider` now have error handling
  so that a transient failure doesn't silently kill the state refresh loop or
  the assign log flush timer.

## Test plan

- [x] New `RecoveringResolverTest` verifying that `ChicoryException` triggers
  recreation but `ChicoryInterruptedException` does not
- [x] Existing integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)