### PR TITLE
fix(js): strip resolveToken from RSC client bundle

### DIFF
--- a/openfeature-provider/js/src/react/server.test.tsx
+++ b/openfeature-provider/js/src/react/server.test.tsx
@@ -149,6 +149,39 @@ describe('ConfidenceProvider', () => {
     });
   });
 
+  describe('resolve token is not exposed to client', () => {
+    it('strips resolveToken from the bundle passed to ConfidenceClientProvider', async () => {
+      const mockProvider = createMockConfidenceProvider();
+      await OpenFeature.setProviderAndWait(mockProvider);
+
+      const result = await ConfidenceProvider({
+        context: { targetingKey: 'user-123' },
+        children: <div>Test</div>,
+      });
+
+      // The bundle prop ships to the browser via the RSC payload — make sure
+      // the resolve token (which carries the full evaluation context and the
+      // resolved variants) does not.
+      const clientProps = (result as React.ReactElement<{ bundle: { resolveToken: string } }>).props;
+      expect(clientProps.bundle.resolveToken).toBe('');
+    });
+
+    it('still applies flags using the original resolve token via the server action closure', async () => {
+      const mockProvider = createMockConfidenceProvider();
+      await OpenFeature.setProviderAndWait(mockProvider);
+
+      const result = await ConfidenceProvider({
+        context: { targetingKey: 'user-123' },
+        children: <div>Test</div>,
+      });
+
+      const clientProps = (result as React.ReactElement<{ apply: (flagName: string) => Promise<void> }>).props;
+      await clientProps.apply('test-flag');
+
+      expect(mockProvider.applyFlag).toHaveBeenCalledWith('test-token', 'test-flag');
+    });
+  });
+
   describe('named providers', () => {
     it('uses named provider when providerName is specified', async () => {
       const defaultProvider = createMockConfidenceProvider();

--- a/openfeature-provider/js/src/react/server.tsx
+++ b/openfeature-provider/js/src/react/server.tsx
@@ -105,8 +105,14 @@ export async function ConfidenceProvider({
     }
   }
 
+  // The resolve token is sensitive (it carries the full evaluation context and
+  // resolved variants) and the client never reads it — strip it before serializing
+  // the bundle into the RSC payload. The server action above keeps the original
+  // bundle in its closure, which Next.js 14+ encrypts.
+  const clientBundle: FlagBundle = { ...bundle, resolveToken: '' };
+
   return (
-    <ConfidenceClientProvider bundle={bundle} apply={applyFlag}>
+    <ConfidenceClientProvider bundle={clientBundle} apply={applyFlag}>
       {children}
     </ConfidenceClientProvider>
   );


### PR DESCRIPTION
## Summary

- The `resolveToken` (which contains the full evaluation context and the resolved variants for each flag) was being shipped to the browser as part of the `bundle` prop on `ConfidenceClientProvider`. The client never reads it.
- The fix strips `resolveToken` from the bundle before passing it to the client component. The `applyFlag` server action keeps closing over the original bundle, which Next.js 14+ [encrypts automatically](https://nextjs.org/blog/security-nextjs-server-components-actions#closures), so apply-time still has the real token.
- Two unit tests added: one asserts the prop is stripped, the other asserts apply still calls `provider.applyFlag` with the original token through the server-action path.

## Why this matters

The resolve token is **not** encrypted by this provider. Anyone inspecting the RSC payload in their browser could pull the token out and decode the targeting context and variant assignments inside it. With this change, the token never leaves the server in the RSC flow.

## End-to-end verification in a real Next.js 14 app

Set up a throwaway Next.js 14 app against a real Confidence client and resolved a flag through `ConfidenceProvider`. Then:

1. Confirmed the initial RSC payload (browser-side HTML) shows the bundle prop with an empty `resolveToken` in both `next dev` and `next build && next start`.
2. Wrote a debug page with a server action that closes over the original token and returns metadata about what it sees on invocation.
3. Clicked the action's button and confirmed:
   - The action's POST body on the wire contains an encrypted closure blob, not the plaintext token.
   - The action body, executing on the server, reconstructs the original token losslessly — the same value `provider.applyFlag` would receive in production.

So the token never reaches the browser in plaintext (neither in the RSC payload nor in the action POST), and is fully intact inside the action body where the apply path needs it.

## Test plan

- [x] `yarn vitest run` — 143/143 passing including the two new tests in `server.test.tsx`
- [x] `yarn typecheck` — clean
- [x] Real Next.js app smoke test in `next dev`
- [x] Real Next.js app smoke test in `next build && next start`
- [x] RSC payload (initial page load) contains no `resolveToken`
- [x] Server-action POST body contains no plaintext `resolveToken`
- [x] Server-action body still receives the original token via the closure

🤖 Generated with [Claude Code](https://claude.com/claude-code)