### PR TITLE
docs: clarify deferred apply / resolve token security

### DIFF
--- a/openfeature-provider/INTEGRATION_GUIDE.md
+++ b/openfeature-provider/INTEGRATION_GUIDE.md
@@ -15,6 +15,7 @@ For language-specific installation and quick start instructions, see your provid
 1. [Getting Your Credentials](#getting-your-credentials)
 2. [Error Handling](#error-handling)
 3. [Sticky Assignments](#sticky-assignments)
+4. [Deferred Apply and Resolve Token Security](#deferred-apply-and-resolve-token-security)
 
 ---
 
@@ -153,6 +154,33 @@ Some providers support custom storage backends to eliminate network calls for st
 ### Deep Dive
 
 For technical details on how sticky assignments work at the protocol level, including flowcharts, behavior matrices, and configuration patterns, see the [Sticky Assignments Technical Guide](../STICKY_ASSIGNMENTS.md).
+
+---
+
+## Deferred Apply and Resolve Token Security
+
+Currently supported in the **Go**, **JavaScript**, and **Java** providers.
+
+When you resolve flags with `apply=false`, the response includes a **resolve token** that you later pass to the apply call to record exposure. This pattern is useful when resolution happens earlier than exposure — for example, resolving on the server but only logging exposure once the client actually renders the experience (see the JS [React integration](js/README-REACT.md) for a typical RSC flow).
+
+### What the resolve token contains
+
+The resolve token is **not encrypted**. It is a serialized payload that includes, among other things:
+
+- The full evaluation context used during resolution (targeting key and any attributes you passed in)
+- Which variant each flag was resolved to
+
+### Recommendation
+
+If any of that data is sensitive (PII in the evaluation context, variant assignments you don't want exposed to end users), do not let the raw token leave your backend. Encrypt the token at the trust boundary and decrypt it again before handing it back to the provider's apply call:
+
+```
+backend ──[ resolve(apply=false) ]──► resolve token (plaintext)
+backend ──[ encrypt ]──► opaque token ──► client / storage / queue
+client ──► opaque token ──► backend ──[ decrypt ]──► resolve token ──► provider.applyFlag(...)
+```
+
+The provider only needs to see the original token at apply time — anything you wrap around it in transit is up to you.
 
 ---
 

--- a/openfeature-provider/go/README.md
+++ b/openfeature-provider/go/README.md
@@ -427,6 +427,8 @@ for _, f := range resp.ResolvedFlags {
 
 When `apply` is `false`, the response contains a `ResolveToken`. Pass it to `ApplyFlags` later to record exposure events — useful when you resolve flags on the server but only want to log exposure once the client actually renders the experience.
 
+> **⚠️ The `ResolveToken` is not encrypted.** It contains the full evaluation context and the resolved variant for each flag. If that data is sensitive, encrypt the token before it leaves your backend and decrypt it before passing it to `ApplyFlags`. See the [Integration Guide: Deferred Apply and Resolve Token Security](../INTEGRATION_GUIDE.md#deferred-apply-and-resolve-token-security).
+
 ```go
 // 1. Resolve without applying
 resp, err := provider.Resolve(ctx, evalCtx, []string{"checkout-flow"}, false)

--- a/openfeature-provider/java/README.md
+++ b/openfeature-provider/java/README.md
@@ -244,6 +244,8 @@ The `FlagResolverService` enables you to proxy flag resolution requests from cli
 - **Context enrichment**: Add server-side context (user ID from auth, request metadata) before resolution
 - **JSON only**: Only `application/json` content type is supported. Requests with other content types will receive a 415 response.
 
+> **⚠️ Resolve tokens returned with `apply=false` are not encrypted.** When a client SDK requests resolution with `apply=false`, the response includes a resolve token containing the full evaluation context and the resolved variant for each flag. If that data is sensitive, encrypt the token in your proxy before returning it to the client SDK and decrypt it again on the apply endpoint before forwarding to `FlagResolverService`. See the [Integration Guide: Deferred Apply and Resolve Token Security](../INTEGRATION_GUIDE.md#deferred-apply-and-resolve-token-security).
+
 ### Basic Setup
 
 ```java

--- a/openfeature-provider/js/README-REACT.md
+++ b/openfeature-provider/js/README-REACT.md
@@ -96,6 +96,17 @@ export function FeatureButton() {
 }
 ```
 
+## Resolve Token Security
+
+`ConfidenceProvider` resolves flags on the server with `apply=false` and returns a bundle that includes a **resolve token** (used at apply time to record exposure). The token contains the full evaluation context (targeting key and any attributes you passed in) and the resolved variant for each flag, and **it is not encrypted by this provider**.
+
+In the React/Next.js flow this provider handles that for you:
+
+- The resolve token is **stripped from the bundle** before it is serialized to the browser, so it never appears in the RSC payload.
+- The `expose()` server action keeps the original token in its closure on the server. Next.js 14+ [encrypts variables captured in server-action closures](https://nextjs.org/blog/security-nextjs-server-components-actions#closures), so the token also isn't exposed via the action reference.
+
+If you call `provider.resolve(..., apply=false)` directly (outside the React integration) and pass the token through your own transport, the security note still applies — see the [Integration Guide: Deferred Apply and Resolve Token Security](../INTEGRATION_GUIDE.md#deferred-apply-and-resolve-token-security).
+
 ## Server vs Client: Understanding Exposure
 
 **Exposure** is the event that tells Confidence a user was shown a particular flag variant. This is critical for accurate experiment analysis.


### PR DESCRIPTION
## Summary

- Add a shared **Deferred Apply and Resolve Token Security** section in `INTEGRATION_GUIDE.md` describing what the resolve token contains (full evaluation context + resolved variants), the fact that it is not encrypted, and the recommended encrypt-on-server / decrypt-before-apply pattern.
- Link to that section from the three places where the token can leave the backend:
  - **Go** — `Direct Resolve API → Deferred apply`
  - **Java** — `HTTP Proxy Service (FlagResolverService)` (the proxy is the only path the token leaves the backend)
  - **JS React (Next.js)** — new `Resolve Token Security` section that explains the RSC integration handles this automatically, and points direct `provider.resolve(..., apply=false)` callers at the integration guide.


## Test plan

- [ ] Render `INTEGRATION_GUIDE.md`, `go/README.md`, `java/README.md`, and `js/README-REACT.md` on GitHub and verify the new sections look right and the cross-links resolve.
- [ ] Confirm #388 is merged before this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)