### PR TITLE
ci: remove release-please debug log step

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,12 +36,6 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      - name: Debug - Log Release Please outputs
-        run: |
-          echo "=== Release Please Outputs ==="
-          echo "All outputs (JSON):"
-          echo '${{ toJSON(steps.releasemanifest.outputs) }}'
-          
   publish-cloudflare-deployer-image:
     needs: release
     if: ${{ needs.release.outputs.cloudflare_resolver_release_created == 'true' }}


### PR DESCRIPTION
## Summary
- The release-please debug step inlined `toJSON(steps.releasemanifest.outputs)` literally inside a single-quoted bash string. Whenever the generated PR body contained an apostrophe or unbalanced shell metachars (e.g. parens in headings), the shell choked with `syntax error near unexpected token '('` and the whole `release` job failed.
- The output isn't needed — drop the step entirely.

Failed example: https://github.com/spotify/confidence-resolver/actions/runs/25094620813/job/73528324969

## Test plan
- [ ] Next push to `main` runs the `release` job to completion and downstream publish jobs gated on outputs proceed normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)