### PR TITLE
feat(js): Next.js Pages Router support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -336,23 +336,26 @@ FROM openfeature-provider-js-base AS openfeature-provider-js.build
 
 RUN make build
 
-# Verify no bundle splitting occurred
+# Verify no bundle splitting occurred. rolldown's default chunkFileNames is
+# `[name]-[hash].js` (8+ alphanumeric hash), so any .js whose basename ends in
+# `-<hash>.js` is an auto-split chunk. Entry outputs are dot-separated
+# (`index.inlined.js`) or path-nested (`pages-router/api.js`), so they don't
+# match this pattern.
 RUN set -e; \
     echo "Verifying no bundle splitting in JS artifacts..."; \
-    UNEXPECTED_FILES=$(find dist -name '*.js' ! -name 'index.node.js' ! -name 'index.inlined.js' ! -name 'index.fetch.js' ! -name 'server.js' ! -name 'client.js' | head -10); \
-    if [ -n "$UNEXPECTED_FILES" ]; then \
+    SPLIT_CHUNKS=$(find dist -type f -name '*.js' | grep -E -- '-[A-Za-z0-9]{8,}\.js$' || true); \
+    if [ -n "$SPLIT_CHUNKS" ]; then \
       echo ""; \
       echo "❌ ERROR: Bundle splitting detected!"; \
       echo ""; \
-      echo "Found unexpected JavaScript files in dist/:"; \
-      echo "$UNEXPECTED_FILES"; \
+      echo "Found auto-split chunks in dist/ (filenames matching <name>-<hash>.js):"; \
+      echo "$SPLIT_CHUNKS"; \
       echo ""; \
-      echo "Only expected entry point files should be present."; \
-      echo "Check tsdown.config.ts configuration to prevent code splitting."; \
+      echo "Each public entry should be a self-contained bundle. Check tsdown.config.ts."; \
       echo ""; \
       exit 1; \
     fi; \
-    echo "✅ No bundle splitting detected - only expected files present"
+    echo "✅ No bundle splitting detected"
 
 # ==============================================================================
 # Pack OpenFeature Provider (JS) - Create tarball for publishing

--- a/openfeature-provider/js/.prettierignore
+++ b/openfeature-provider/js/.prettierignore
@@ -7,3 +7,4 @@ coverage/*
 api/*
 CHANGELOG.md
 README.md
+CLAUDE.md

--- a/openfeature-provider/js/README-REACT.md
+++ b/openfeature-provider/js/README-REACT.md
@@ -402,25 +402,22 @@ Provider registration is router-agnostic: use the same [`instrumentation.ts`](#1
 
 ### 1. Resolve flags in `getServerSideProps`
 
-`withConfidence` wraps your `getServerSideProps`, resolves the flag bundle for the request without firing exposure, and merges it into `pageProps.confidence`. You hand it an `EvaluationContext` (or a function that builds one from the request) and optionally a list of flag keys to scope the resolution.
-
-If your page already has its own `getServerSideProps`, pass it as the second argument:
+`withConfidence` wraps a single `getServerSideProps`-shaped function that does your data fetching **and** returns the evaluation context to use for flag resolution (and optionally a `flags` allow-list). The decorator resolves the bundle without firing exposure, seals the resolve token, and merges it into `pageProps.confidence`.
 
 ```tsx
 // pages/index.tsx
 import { useFlag } from '@spotify-confidence/openfeature-server-provider-local/react-client';
 import { withConfidence } from '@spotify-confidence/openfeature-server-provider-local/pages-router/server';
 
-export const getServerSideProps = withConfidence(
-  {
-    context: ({ req }) => ({ targetingKey: req.cookies.uid ?? 'anon' }),
+export const getServerSideProps = withConfidence(async ({ req }) => {
+  const visitorId = req.cookies.uid ?? 'anon';
+  const data = await fetchSomeData();
+  return {
+    props: { data },
+    context: { visitor_id: visitorId },
     flags: ['my-feature'], // optional — defaults to all flags
-  },
-  async () => {
-    const data = await fetchSomeData();
-    return { props: { data } };
-  },
-);
+  };
+});
 
 export default function Home({ data }: { data: SomeData }) {
   const enabled = useFlag('my-feature.enabled', false);
@@ -428,12 +425,13 @@ export default function Home({ data }: { data: SomeData }) {
 }
 ```
 
-For pages with no other data fetching, omit the second argument:
+Returning `{ redirect }` or `{ notFound }` short-circuits before flag resolution, just like a normal `getServerSideProps`. For pages without their own data fetching, the body collapses to a single return:
 
 ```tsx
-export const getServerSideProps = withConfidence({
-  context: ({ req }) => ({ targetingKey: req.cookies.uid ?? 'anon' }),
-});
+export const getServerSideProps = withConfidence(async ({ req }) => ({
+  props: {},
+  context: { visitor_id: req.cookies.uid ?? 'anon' },
+}));
 ```
 
 ### 2. Wrap your tree with `<ConfidencePagesProvider>`

--- a/openfeature-provider/js/README-REACT.md
+++ b/openfeature-provider/js/README-REACT.md
@@ -37,20 +37,24 @@ yarn add @spotify-confidence/openfeature-server-provider-local react
 
 ### 1. Set up the provider (server-side)
 
-Create a file to initialize the OpenFeature provider:
+Use Next.js's [`instrumentation.ts`](https://nextjs.org/docs/app/api-reference/file-conventions/instrumentation) hook to register the provider once at server startup:
 
 ```ts
-// lib/confidence.ts
-import { OpenFeature } from '@openfeature/server-sdk';
-import { createConfidenceServerProvider } from '@spotify-confidence/openfeature-server-provider-local';
+// instrumentation.ts (at the project root, or in src/ if you use a src folder)
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return;
 
-const provider = createConfidenceServerProvider({
-  flagClientSecret: process.env.CONFIDENCE_FLAG_CLIENT_SECRET!,
-});
+  const { OpenFeature } = await import('@openfeature/server-sdk');
+  const { createConfidenceServerProvider } = await import('@spotify-confidence/openfeature-server-provider-local');
 
-// Initialize once at startup
-await OpenFeature.setProviderAndWait(provider);
+  const provider = createConfidenceServerProvider({
+    flagClientSecret: process.env.CONFIDENCE_FLAG_CLIENT_SECRET!,
+  });
+  await OpenFeature.setProviderAndWait(provider);
+}
 ```
+
+`register` runs once when a Next.js server instance boots and is awaited before requests are served. It does not run during `next build`, so it's safe to perform network setup here.
 
 ### 2. Wrap your app with ConfidenceProvider
 
@@ -59,7 +63,6 @@ In your layout or page (Server Component):
 ```tsx
 // app/layout.tsx
 import { ConfidenceProvider } from '@spotify-confidence/openfeature-server-provider-local/react-server';
-import './lib/confidence'; // Initialize provider
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   // Get user context from session, cookies, etc.
@@ -386,6 +389,100 @@ export default async function Page() {
   return showNewLayout ? <NewLayout /> : <OldLayout />;
 }
 ```
+
+## Next.js Pages Router
+
+When using the Pages Router, three subexports under `./pages-router/*` cover the equivalent of the App Router integration above. The client hooks (`useFlag`, `useFlagDetails`) are the same — only the server plumbing differs.
+
+- **`pages-router/server`** — `withConfidence`, a `getServerSideProps` decorator that resolves the flag bundle for the request and merges it into `pageProps`.
+- **`pages-router/client`** — `<ConfidencePagesProvider>`, which reads the bundle from `pageProps` and exposes it to the `useFlag` / `useFlagDetails` hooks (re-used as-is from `react-client`).
+- **`pages-router/api`** — `applyHandler`, the `/api/confidence/apply` POST handler the client uses to log exposure when a flag is read.
+
+Provider registration is router-agnostic: use the same [`instrumentation.ts`](#1-set-up-the-provider-server-side) setup shown for the App Router.
+
+### 1. Resolve flags in `getServerSideProps`
+
+`withConfidence` wraps your `getServerSideProps`, resolves the flag bundle for the request without firing exposure, and merges it into `pageProps.confidence`. You hand it an `EvaluationContext` (or a function that builds one from the request) and optionally a list of flag keys to scope the resolution.
+
+If your page already has its own `getServerSideProps`, pass it as the second argument:
+
+```tsx
+// pages/index.tsx
+import { useFlag } from '@spotify-confidence/openfeature-server-provider-local/react-client';
+import { withConfidence } from '@spotify-confidence/openfeature-server-provider-local/pages-router/server';
+
+export const getServerSideProps = withConfidence(
+  {
+    context: ({ req }) => ({ targetingKey: req.cookies.uid ?? 'anon' }),
+    flags: ['my-feature'], // optional — defaults to all flags
+  },
+  async () => {
+    const data = await fetchSomeData();
+    return { props: { data } };
+  },
+);
+
+export default function Home({ data }: { data: SomeData }) {
+  const enabled = useFlag('my-feature.enabled', false);
+  return enabled ? <Feature data={data} /> : null;
+}
+```
+
+For pages with no other data fetching, omit the second argument:
+
+```tsx
+export const getServerSideProps = withConfidence({
+  context: ({ req }) => ({ targetingKey: req.cookies.uid ?? 'anon' }),
+});
+```
+
+### 2. Wrap your tree with `<ConfidencePagesProvider>`
+
+Any component that calls `useFlag` / `useFlagDetails` must sit under a `<ConfidencePagesProvider>`. The simplest placement is `_app.tsx`, which covers every page in one spot — but the wrapper works anywhere in the tree, so per-page wrapping is also fine if you'd rather not touch `_app.tsx`.
+
+```tsx
+// pages/_app.tsx
+import type { AppProps } from 'next/app';
+import { ConfidencePagesProvider } from '@spotify-confidence/openfeature-server-provider-local/pages-router/client';
+
+export default function App({ Component, pageProps }: AppProps) {
+  const { confidence, ...rest } = pageProps;
+  return (
+    <ConfidencePagesProvider confidence={confidence}>
+      <Component {...rest} />
+    </ConfidencePagesProvider>
+  );
+}
+```
+
+Pages whose `getServerSideProps` doesn't use `withConfidence` simply have no `confidence` key on `pageProps`; the wrapper short-circuits and any `useFlag` calls in their tree fall back to default values.
+
+### 3. Mount the apply API route
+
+When a flag is read on the client (e.g. `useFlag` firing on mount), the wrapper POSTs `{ resolveToken, flagName }` to the apply route, which opens the sealed token and logs exposure server-side. Mount the handler at `/api/confidence/apply`:
+
+```ts
+// pages/api/confidence/apply.ts
+import { applyHandler } from '@spotify-confidence/openfeature-server-provider-local/pages-router/api';
+export default applyHandler();
+```
+
+If you need to mount it elsewhere, pass the same path to `<ConfidencePagesProvider apiPath="...">`.
+
+### Resolve token security
+
+In the App Router, the resolve token stays in the encrypted closure of a server action. The Pages Router has no equivalent, so the lib **seals the token with AES-256-GCM** before it ever reaches the browser. Set a server-only key:
+
+```bash
+CONFIDENCE_TOKEN_KEY=$(openssl rand -hex 32)
+```
+
+The client only ever sees the sealed value; the apply API route opens it server-side.
+
+### What's not in this integration
+
+- No equivalent to `getFlag` / `getFlagDetails` server functions — call `OpenFeature.getClient().getXxxValue(...)` directly inside `getServerSideProps` if you need eager-exposure server-only resolution.
+- No `getStaticProps` support: flag resolution is per-request and depends on evaluation context.
 
 ## Troubleshooting
 

--- a/openfeature-provider/js/package.json
+++ b/openfeature-provider/js/package.json
@@ -32,6 +32,18 @@
       "types": "./dist/client.d.ts",
       "default": "./dist/client.js"
     },
+    "./pages-router/server": {
+      "types": "./dist/pages-router/server.d.ts",
+      "default": "./dist/pages-router/server.js"
+    },
+    "./pages-router/client": {
+      "types": "./dist/pages-router/client.d.ts",
+      "default": "./dist/pages-router/client.js"
+    },
+    "./pages-router/api": {
+      "types": "./dist/pages-router/api.d.ts",
+      "default": "./dist/pages-router/api.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -60,6 +72,7 @@
     "debug": "^4.4.3",
     "dotenv": "^17.2.2",
     "happy-dom": "^20.3.4",
+    "next": "^16.0.0",
     "prettier": "^2.8.8",
     "react": "^19",
     "react-dom": "^19.2.3",
@@ -72,6 +85,7 @@
   "peerDependencies": {
     "@openfeature/core": "^1.0.0",
     "debug": "^4.4.3",
+    "next": ">=13.0.0",
     "react": "^18.0.0 || ^19.0.0"
   },
   "peerDependenciesMeta": {
@@ -79,6 +93,9 @@
       "optional": true
     },
     "debug": {
+      "optional": true
+    },
+    "next": {
       "optional": true
     },
     "react": {

--- a/openfeature-provider/js/src/pages-router/api.test.ts
+++ b/openfeature-provider/js/src/pages-router/api.test.ts
@@ -1,0 +1,92 @@
+import { OpenFeature } from '@openfeature/server-sdk';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { applyHandler } from './api';
+import { __resetKeyCacheForTests, sealResolveToken } from './token';
+
+function makeReqRes(
+  method: string,
+  body?: unknown,
+): { req: NextApiRequest; res: NextApiResponse; status: () => number } {
+  const headers: Record<string, string> = {};
+  let statusCode = 200;
+  const res = {
+    setHeader: vi.fn((k: string, v: string) => {
+      headers[k] = v;
+    }),
+    status: vi.fn((code: number) => {
+      statusCode = code;
+      return res;
+    }),
+    end: vi.fn(),
+  } as unknown as NextApiResponse;
+  const req = { method, body } as NextApiRequest;
+  return { req, res, status: () => statusCode };
+}
+
+describe('applyHandler', () => {
+  beforeAll(() => {
+    process.env.CONFIDENCE_TOKEN_KEY = 'test-key-do-not-use-in-prod';
+    __resetKeyCacheForTests();
+  });
+
+  afterEach(() => {
+    OpenFeature.clearProviders();
+  });
+
+  it('returns 405 for non-POST', async () => {
+    const handler = applyHandler();
+    const { req, res, status } = makeReqRes('GET');
+    await handler(req, res);
+    expect(status()).toBe(405);
+    expect(res.setHeader).toHaveBeenCalledWith('Allow', 'POST');
+  });
+
+  it('returns 400 when body is missing', async () => {
+    const handler = applyHandler();
+    const { req, res, status } = makeReqRes('POST');
+    await handler(req, res);
+    expect(status()).toBe(400);
+  });
+
+  it('returns 400 when fields have wrong types', async () => {
+    const handler = applyHandler();
+    const { req, res, status } = makeReqRes('POST', { resolveToken: 123, flagName: 'x' });
+    await handler(req, res);
+    expect(status()).toBe(400);
+  });
+
+  it('returns 503 when no Confidence provider is registered', async () => {
+    const handler = applyHandler();
+    const sealed = sealResolveToken('opaque');
+    const { req, res, status } = makeReqRes('POST', { resolveToken: sealed, flagName: 'my-flag' });
+    await handler(req, res);
+    expect(status()).toBe(503);
+  });
+
+  it('returns 400 when the resolveToken cannot be opened', async () => {
+    // Register a real-shaped provider so the 503 branch doesn't shortcut.
+    OpenFeature.setProvider({
+      metadata: { name: 'ConfidenceServerProviderLocal' },
+      applyFlag: vi.fn(),
+    } as never);
+    const handler = applyHandler();
+    const { req, res, status } = makeReqRes('POST', { resolveToken: 'not-a-real-handle', flagName: 'x' });
+    await handler(req, res);
+    expect(status()).toBe(400);
+  });
+
+  it('calls applyFlag on success and returns 204', async () => {
+    const applyFlag = vi.fn();
+    OpenFeature.setProvider({
+      metadata: { name: 'ConfidenceServerProviderLocal' },
+      applyFlag,
+    } as never);
+    const sealed = sealResolveToken('the-real-token');
+    const handler = applyHandler();
+    const { req, res, status } = makeReqRes('POST', { resolveToken: sealed, flagName: 'my-flag' });
+    await handler(req, res);
+    expect(applyFlag).toHaveBeenCalledWith('the-real-token', 'my-flag');
+    expect(status()).toBe(204);
+  });
+});

--- a/openfeature-provider/js/src/pages-router/api.test.ts
+++ b/openfeature-provider/js/src/pages-router/api.test.ts
@@ -76,6 +76,20 @@ describe('applyHandler', () => {
     expect(status()).toBe(400);
   });
 
+  it('skips applyFlag and returns 204 when the opened token is empty (error bundle)', async () => {
+    const applyFlag = vi.fn();
+    OpenFeature.setProvider({
+      metadata: { name: 'ConfidenceServerProviderLocal' },
+      applyFlag,
+    } as never);
+    const sealed = sealResolveToken(''); // FlagBundle.error() ships resolveToken: ''
+    const handler = applyHandler();
+    const { req, res, status } = makeReqRes('POST', { resolveToken: sealed, flagName: 'my-flag' });
+    await handler(req, res);
+    expect(applyFlag).not.toHaveBeenCalled();
+    expect(status()).toBe(204);
+  });
+
   it('calls applyFlag on success and returns 204', async () => {
     const applyFlag = vi.fn();
     OpenFeature.setProvider({

--- a/openfeature-provider/js/src/pages-router/api.ts
+++ b/openfeature-provider/js/src/pages-router/api.ts
@@ -45,6 +45,13 @@ export function applyHandler(opts: ApplyHandlerOptions = {}): NextApiHandler {
       return;
     }
 
+    // Error bundles carry an empty resolveToken (see FlagBundle.error); skip
+    // applyFlag in that case to match the App Router's `!bundle.errorCode` gate.
+    if (!openedToken) {
+      res.status(204).end();
+      return;
+    }
+
     provider.applyFlag(openedToken, body.flagName);
     res.status(204).end();
   };

--- a/openfeature-provider/js/src/pages-router/api.ts
+++ b/openfeature-provider/js/src/pages-router/api.ts
@@ -1,0 +1,51 @@
+import type { NextApiHandler } from 'next';
+import { getConfidenceProvider } from './common';
+import { openResolveToken } from './token';
+
+export interface ApplyHandlerOptions {
+  /** Use a non-default OpenFeature provider by name. */
+  providerName?: string;
+}
+
+/**
+ * Builds the POST handler that the client `ConfidencePagesProvider` calls to
+ * fire exposure events. Mount it at `/api/confidence/apply` (or pass a custom
+ * `apiPath` to `ConfidencePagesProvider` if you mount it elsewhere).
+ *
+ * @example
+ * // pages/api/confidence/apply.ts
+ * import { applyHandler } from '@spotify-confidence/openfeature-server-provider-local/pages-router/api';
+ * export default applyHandler();
+ */
+export function applyHandler(opts: ApplyHandlerOptions = {}): NextApiHandler {
+  return async (req, res) => {
+    if (req.method !== 'POST') {
+      res.setHeader('Allow', 'POST');
+      res.status(405).end();
+      return;
+    }
+
+    const body = req.body as { resolveToken?: unknown; flagName?: unknown } | undefined;
+    if (!body || typeof body.resolveToken !== 'string' || typeof body.flagName !== 'string') {
+      res.status(400).end();
+      return;
+    }
+
+    const provider = getConfidenceProvider(opts.providerName);
+    if (!provider) {
+      res.status(503).end();
+      return;
+    }
+
+    let openedToken: string;
+    try {
+      openedToken = openResolveToken(body.resolveToken);
+    } catch {
+      res.status(400).end();
+      return;
+    }
+
+    provider.applyFlag(openedToken, body.flagName);
+    res.status(204).end();
+  };
+}

--- a/openfeature-provider/js/src/pages-router/client.tsx
+++ b/openfeature-provider/js/src/pages-router/client.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, type ReactNode } from 'react';
+// Package self-reference so the pages-router/client bundle does NOT inline
+// react/client — otherwise we'd ship two copies of `ConfidenceContext` and
+// `<ConfidencePagesProvider>` would write to a different context than the one
+// `useFlag` / `useFlagDetails` read from. The consumer's bundler resolves
+// this via the package's `./react-client` exports entry and dedupes it against
+// any other usage of react-client in the same app.
+import { ConfidenceClientProvider } from '@spotify-confidence/openfeature-server-provider-local/react-client';
+import { DEFAULT_APPLY_PATH } from './constants';
+import type { ConfidencePageProps } from './types';
+
+export type { ConfidencePageProps } from './types';
+
+interface Props {
+  /**
+   * The Confidence payload returned from `withConfidence` in
+   * `getServerSideProps`, normally pulled out of `pageProps` in `_app.tsx`.
+   * Pages that don't resolve flags pass `undefined` and any `useFlag` /
+   * `useFlagDetails` calls in their tree return defaults.
+   */
+  confidence?: ConfidencePageProps;
+  /** Override the apply API route. Must match where you mount `applyHandler`. */
+  apiPath?: string;
+  children: ReactNode;
+}
+
+/**
+ * Place at the top of `_app.tsx`. Bridges the bundle resolved on the server
+ * to the client `useFlag` / `useFlagDetails` hooks.
+ */
+export function ConfidencePagesProvider({
+  confidence,
+  apiPath = DEFAULT_APPLY_PATH,
+  children,
+}: Props): React.ReactElement {
+  const resolveToken = confidence?.resolveToken;
+
+  const apply = useCallback(
+    async (flagName: string) => {
+      if (!resolveToken) return;
+      await fetch(apiPath, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ resolveToken, flagName }),
+        keepalive: true,
+      });
+    },
+    [resolveToken, apiPath],
+  );
+
+  if (!confidence) return <>{children}</>;
+  return (
+    <ConfidenceClientProvider bundle={confidence} apply={apply}>
+      {children}
+    </ConfidenceClientProvider>
+  );
+}

--- a/openfeature-provider/js/src/pages-router/client.tsx
+++ b/openfeature-provider/js/src/pages-router/client.tsx
@@ -8,8 +8,9 @@ import { useCallback, type ReactNode } from 'react';
 // this via the package's `./react-client` exports entry and dedupes it against
 // any other usage of react-client in the same app.
 import { ConfidenceClientProvider } from '@spotify-confidence/openfeature-server-provider-local/react-client';
-import { DEFAULT_APPLY_PATH } from './constants';
 import type { ConfidencePageProps } from './types';
+
+const DEFAULT_APPLY_PATH = '/api/confidence/apply';
 
 export type { ConfidencePageProps } from './types';
 
@@ -40,12 +41,26 @@ export function ConfidencePagesProvider({
   const apply = useCallback(
     async (flagName: string) => {
       if (!resolveToken) return;
-      await fetch(apiPath, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ resolveToken, flagName }),
-        keepalive: true,
-      });
+      try {
+        const res = await fetch(apiPath, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ resolveToken, flagName }),
+          keepalive: true,
+        });
+        if (!res.ok && process.env.NODE_ENV !== 'production') {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[Confidence] apply failed: ${res.status} ${res.statusText}. ` +
+              `Mount applyHandler at ${apiPath} and ensure a ConfidenceServerProviderLocal is registered.`,
+          );
+        }
+      } catch (err) {
+        if (process.env.NODE_ENV !== 'production') {
+          // eslint-disable-next-line no-console
+          console.warn('[Confidence] apply request failed:', err);
+        }
+      }
     },
     [resolveToken, apiPath],
   );

--- a/openfeature-provider/js/src/pages-router/common.ts
+++ b/openfeature-provider/js/src/pages-router/common.ts
@@ -1,0 +1,17 @@
+import { OpenFeature } from '@openfeature/server-sdk';
+import type { ConfidenceProvider } from './types';
+
+const PROVIDER_NAME = 'ConfidenceServerProviderLocal';
+
+/**
+ * Resolves the OpenFeature provider and narrows it to a Confidence provider.
+ * Returns `null` if the registered provider is not a `ConfidenceServerProviderLocal`
+ * — the user is expected to register one (typically in `instrumentation.ts`).
+ *
+ * Mirrors `isConfidenceServerProviderLocal` from the App Router integration.
+ */
+export function getConfidenceProvider(providerName?: string): ConfidenceProvider | null {
+  const provider = providerName ? OpenFeature.getProvider(providerName) : OpenFeature.getProvider();
+  if (provider?.metadata?.name !== PROVIDER_NAME) return null;
+  return provider as ConfidenceProvider;
+}

--- a/openfeature-provider/js/src/pages-router/constants.ts
+++ b/openfeature-provider/js/src/pages-router/constants.ts
@@ -1,1 +1,0 @@
-export const DEFAULT_APPLY_PATH = '/api/confidence/apply';

--- a/openfeature-provider/js/src/pages-router/constants.ts
+++ b/openfeature-provider/js/src/pages-router/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_APPLY_PATH = '/api/confidence/apply';

--- a/openfeature-provider/js/src/pages-router/server.ts
+++ b/openfeature-provider/js/src/pages-router/server.ts
@@ -1,0 +1,69 @@
+import type { EvaluationContext } from '@openfeature/server-sdk';
+import type { GetServerSideProps, GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
+import * as FlagBundle from '../flag-bundle';
+import { ErrorCode } from '../types';
+import { getConfidenceProvider } from './common';
+import { sealResolveToken } from './token';
+import type { ConfidencePageProps } from './types';
+
+export type { ConfidencePageProps } from './types';
+
+export interface WithConfidenceConfig {
+  /**
+   * Evaluation context for flag resolution. Either a static value or a function
+   * that derives one from the request. Mirrors `<ConfidenceProvider context>`
+   * from the App Router integration.
+   */
+  context: EvaluationContext | ((ctx: GetServerSidePropsContext) => EvaluationContext | Promise<EvaluationContext>);
+  /** Restrict resolution to a subset of flags. Defaults to all. */
+  flags?: string[];
+  /** Use a non-default OpenFeature provider by name. */
+  providerName?: string;
+}
+
+/**
+ * Low-level: resolve flags into a `ConfidencePageProps` payload. Most callers
+ * should use `withConfidence` instead.
+ */
+export async function resolveConfidence(
+  config: WithConfidenceConfig,
+  ctx: GetServerSidePropsContext,
+): Promise<ConfidencePageProps> {
+  const provider = getConfidenceProvider(config.providerName);
+  if (!provider) {
+    return FlagBundle.error(
+      ErrorCode.GENERAL,
+      `OpenFeature provider${
+        config.providerName ? ` "${config.providerName}"` : ''
+      } is not a ConfidenceServerProviderLocal. Register one with OpenFeature.setProviderAndWait — typically in instrumentation.ts.`,
+    );
+  }
+
+  const context = typeof config.context === 'function' ? await config.context(ctx) : config.context;
+  const bundle = await provider.resolve(context, config.flags ?? []);
+  // Replace the raw resolveToken in place with its sealed (AES-GCM) form.
+  // The apply API route opens it; the client never sees the raw value.
+  return { ...bundle, resolveToken: sealResolveToken(bundle.resolveToken) };
+}
+
+/**
+ * Resolves flags and merges `confidence` into `props`. Composes with a user
+ * gSSP that returns its own `props` / `redirect` / `notFound`. Pages without
+ * their own data fetching call it without a second argument.
+ */
+export function withConfidence<P extends Record<string, unknown> = {}>(
+  config: WithConfidenceConfig,
+  inner?: GetServerSideProps<P>,
+): GetServerSideProps<P & { confidence?: ConfidencePageProps }> {
+  return async ctx => {
+    const innerResult: GetServerSidePropsResult<P> = inner ? await inner(ctx) : { props: {} as P };
+
+    if ('redirect' in innerResult || 'notFound' in innerResult) {
+      return innerResult as GetServerSidePropsResult<P>;
+    }
+
+    const innerProps = (await Promise.resolve(innerResult.props)) as P;
+    const confidence = await resolveConfidence(config, ctx);
+    return { ...innerResult, props: { ...innerProps, confidence } };
+  };
+}

--- a/openfeature-provider/js/src/pages-router/server.ts
+++ b/openfeature-provider/js/src/pages-router/server.ts
@@ -1,5 +1,5 @@
 import type { EvaluationContext } from '@openfeature/server-sdk';
-import type { GetServerSideProps, GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
+import type { GetServerSideProps, GetServerSidePropsContext, GetServerSidePropsResult, Redirect } from 'next';
 import * as FlagBundle from '../flag-bundle';
 import { ErrorCode } from '../types';
 import { getConfidenceProvider } from './common';
@@ -8,62 +8,95 @@ import type { ConfidencePageProps } from './types';
 
 export type { ConfidencePageProps } from './types';
 
-export interface WithConfidenceConfig {
-  /**
-   * Evaluation context for flag resolution. Either a static value or a function
-   * that derives one from the request. Mirrors `<ConfidenceProvider context>`
-   * from the App Router integration.
-   */
-  context: EvaluationContext | ((ctx: GetServerSidePropsContext) => EvaluationContext | Promise<EvaluationContext>);
-  /** Restrict resolution to a subset of flags. Defaults to all. */
-  flags?: string[];
+export interface WithConfidenceOptions {
   /** Use a non-default OpenFeature provider by name. */
   providerName?: string;
 }
 
 /**
- * Low-level: resolve flags into a `ConfidencePageProps` payload. Most callers
- * should use `withConfidence` instead.
+ * Return type of the function passed to `withConfidence`. Augments the standard
+ * `getServerSideProps` shape with a required `context` (the evaluation context
+ * for flag resolution) and an optional `flags` allow-list.
+ */
+export type WithConfidenceResult<P extends { [key: string]: any; confidence?: never }> =
+  | {
+      props: P | Promise<P>;
+      /**
+       * Evaluation context for flag resolution. Omit to skip flag resolution
+       * entirely for this request — `pageProps.confidence` will be absent and
+       * any `useFlag` / `useFlagDetails` calls in the tree fall back to
+       * default values. Useful when flag access is conditional (e.g.
+       * unauthenticated requests).
+       */
+      context?: EvaluationContext;
+      /** Restrict resolution to a subset of flags. Defaults to all. */
+      flags?: string[];
+    }
+  | { redirect: Redirect }
+  | { notFound: true };
+
+function providerMissingBundle(providerName?: string): ConfidencePageProps {
+  return FlagBundle.error(
+    ErrorCode.GENERAL,
+    `OpenFeature provider${
+      providerName ? ` "${providerName}"` : ''
+    } is not a ConfidenceServerProviderLocal. Register one with OpenFeature.setProviderAndWait — typically in instrumentation.ts.`,
+  );
+}
+
+/**
+ * Low-level: resolve flags into a `ConfidencePageProps` payload. Use this if
+ * you want flag resolution outside the `withConfidence` flow (e.g. inside a
+ * custom decorator). Most callers should just use `withConfidence`.
  */
 export async function resolveConfidence(
-  config: WithConfidenceConfig,
-  ctx: GetServerSidePropsContext,
+  context: EvaluationContext,
+  opts: { flags?: string[]; providerName?: string } = {},
 ): Promise<ConfidencePageProps> {
-  const provider = getConfidenceProvider(config.providerName);
-  if (!provider) {
-    return FlagBundle.error(
-      ErrorCode.GENERAL,
-      `OpenFeature provider${
-        config.providerName ? ` "${config.providerName}"` : ''
-      } is not a ConfidenceServerProviderLocal. Register one with OpenFeature.setProviderAndWait — typically in instrumentation.ts.`,
-    );
-  }
-
-  const context = typeof config.context === 'function' ? await config.context(ctx) : config.context;
-  const bundle = await provider.resolve(context, config.flags ?? []);
+  const provider = getConfidenceProvider(opts.providerName);
+  if (!provider) return providerMissingBundle(opts.providerName);
+  const bundle = await provider.resolve(context, opts.flags ?? []);
   // Replace the raw resolveToken in place with its sealed (AES-GCM) form.
   // The apply API route opens it; the client never sees the raw value.
   return { ...bundle, resolveToken: sealResolveToken(bundle.resolveToken) };
 }
 
 /**
- * Resolves flags and merges `confidence` into `props`. Composes with a user
- * gSSP that returns its own `props` / `redirect` / `notFound`. Pages without
- * their own data fetching call it without a second argument.
+ * `getServerSideProps` decorator. Pass a single function that does your data
+ * fetching AND returns the evaluation context for flag resolution. The
+ * decorator resolves the flag bundle, seals it, and merges it into
+ * `pageProps.confidence`.
+ *
+ * Returning `{ redirect }` or `{ notFound }` short-circuits before flag
+ * resolution, just like a normal `getServerSideProps`.
+ *
+ * @example
+ * export const getServerSideProps = withConfidence(async ({ req }) => {
+ *   const visitorId = req.cookies.uid ?? 'anon';
+ *   const data = await fetchSomeData();
+ *   return {
+ *     props: { data },
+ *     context: { visitor_id: visitorId },
+ *   };
+ * });
  */
-export function withConfidence<P extends Record<string, unknown> = {}>(
-  config: WithConfidenceConfig,
-  inner?: GetServerSideProps<P>,
+export function withConfidence<P extends { [key: string]: any; confidence?: never } = {}>(
+  gssp: (ctx: GetServerSidePropsContext) => Promise<WithConfidenceResult<P>>,
+  opts: WithConfidenceOptions = {},
 ): GetServerSideProps<P & { confidence?: ConfidencePageProps }> {
   return async ctx => {
-    const innerResult: GetServerSidePropsResult<P> = inner ? await inner(ctx) : { props: {} as P };
-
-    if ('redirect' in innerResult || 'notFound' in innerResult) {
-      return innerResult as GetServerSidePropsResult<P>;
+    const result = await gssp(ctx);
+    if (!('props' in result)) {
+      return result as GetServerSidePropsResult<P & { confidence?: ConfidencePageProps }>;
     }
-
-    const innerProps = (await Promise.resolve(innerResult.props)) as P;
-    const confidence = await resolveConfidence(config, ctx);
-    return { ...innerResult, props: { ...innerProps, confidence } };
+    const innerProps = (await Promise.resolve(result.props)) as P;
+    if (result.context === undefined) {
+      return { props: innerProps };
+    }
+    const confidence = await resolveConfidence(result.context, {
+      flags: result.flags,
+      providerName: opts.providerName,
+    });
+    return { props: { ...innerProps, confidence } };
   };
 }

--- a/openfeature-provider/js/src/pages-router/token.test.ts
+++ b/openfeature-provider/js/src/pages-router/token.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { __resetKeyCacheForTests, openResolveToken, sealResolveToken } from './token';
+
+describe('sealResolveToken / openResolveToken', () => {
+  beforeAll(() => {
+    process.env.CONFIDENCE_TOKEN_KEY = 'test-key-do-not-use-in-prod';
+    __resetKeyCacheForTests();
+  });
+
+  afterEach(() => {
+    process.env.CONFIDENCE_TOKEN_KEY = 'test-key-do-not-use-in-prod';
+    __resetKeyCacheForTests();
+  });
+
+  it('round-trips a typical resolve token', () => {
+    const token = 'abc.def.ghi-some-base64-ish-resolve-token==';
+    const sealed = sealResolveToken(token);
+    expect(sealed).not.toContain(token);
+    expect(openResolveToken(sealed)).toBe(token);
+  });
+
+  it('round-trips an empty string', () => {
+    const sealed = sealResolveToken('');
+    expect(openResolveToken(sealed)).toBe('');
+  });
+
+  it('produces a different ciphertext each call (random IV)', () => {
+    const token = 'same-input';
+    expect(sealResolveToken(token)).not.toBe(sealResolveToken(token));
+  });
+
+  it('rejects a tampered ciphertext (auth tag mismatch)', () => {
+    const sealed = sealResolveToken('something');
+    // Flip a byte in the ciphertext region.
+    const buf = Buffer.from(sealed, 'base64url');
+    buf[buf.length - 1] ^= 0x01;
+    const tampered = buf.toString('base64url');
+    expect(() => openResolveToken(tampered)).toThrow();
+  });
+
+  it('rejects a too-short handle', () => {
+    expect(() => openResolveToken('AAAA')).toThrow('Invalid Confidence handle');
+  });
+
+  it('rejects a handle sealed with a different key', () => {
+    const sealed = sealResolveToken('payload');
+    process.env.CONFIDENCE_TOKEN_KEY = 'a-different-key';
+    __resetKeyCacheForTests();
+    expect(() => openResolveToken(sealed)).toThrow();
+  });
+
+  it('throws if CONFIDENCE_TOKEN_KEY is unset', () => {
+    delete process.env.CONFIDENCE_TOKEN_KEY;
+    __resetKeyCacheForTests();
+    expect(() => sealResolveToken('x')).toThrow(/CONFIDENCE_TOKEN_KEY/);
+  });
+});

--- a/openfeature-provider/js/src/pages-router/token.ts
+++ b/openfeature-provider/js/src/pages-router/token.ts
@@ -1,0 +1,49 @@
+import { createCipheriv, createDecipheriv, createHash, randomBytes } from 'node:crypto';
+
+// AES-256-GCM. The resolve token carries the full evaluation context and the
+// resolved variants — never let the client see it. We seal it with a server
+// key so the client can only round-trip an opaque handle through the apply API
+// route. Mirrors what App Router gets for free via encrypted server actions.
+
+const ALGO = 'aes-256-gcm';
+const IV_LEN = 12;
+const TAG_LEN = 16;
+
+let cachedKey: Buffer | null = null;
+function getKey(): Buffer {
+  if (cachedKey) return cachedKey;
+  const raw = process.env.CONFIDENCE_TOKEN_KEY;
+  if (!raw) {
+    throw new Error(
+      'CONFIDENCE_TOKEN_KEY is not set. Generate one with: openssl rand -hex 32 — and set it in the server environment.',
+    );
+  }
+  cachedKey = createHash('sha256').update(raw).digest();
+  return cachedKey;
+}
+
+export function sealResolveToken(token: string): string {
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv(ALGO, getKey(), iv);
+  const ciphertext = Buffer.concat([cipher.update(token, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, ciphertext]).toString('base64url');
+}
+
+export function openResolveToken(handle: string): string {
+  const buf = Buffer.from(handle, 'base64url');
+  if (buf.length < IV_LEN + TAG_LEN) {
+    throw new Error('Invalid Confidence handle');
+  }
+  const iv = buf.subarray(0, IV_LEN);
+  const tag = buf.subarray(IV_LEN, IV_LEN + TAG_LEN);
+  const ciphertext = buf.subarray(IV_LEN + TAG_LEN);
+  const decipher = createDecipheriv(ALGO, getKey(), iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+}
+
+/** @internal Test-only: clear the cached key so a fresh env var is picked up. */
+export function __resetKeyCacheForTests(): void {
+  cachedKey = null;
+}

--- a/openfeature-provider/js/src/pages-router/types.ts
+++ b/openfeature-provider/js/src/pages-router/types.ts
@@ -1,0 +1,13 @@
+import type FlagBundleType from '../flag-bundle';
+import type { ConfidenceServerProviderLocal } from '../ConfidenceServerProviderLocal';
+
+export type FlagBundle = FlagBundleType;
+export type ConfidenceProvider = ConfidenceServerProviderLocal;
+
+/**
+ * Server-to-client transport payload returned from `withConfidence` and
+ * consumed by `<ConfidencePagesProvider>`. Structurally a `FlagBundle` whose
+ * `resolveToken` has been sealed (AES-GCM) — the apply API route is the only
+ * thing that opens it.
+ */
+export type ConfidencePageProps = FlagBundle;

--- a/openfeature-provider/js/tsconfig.json
+++ b/openfeature-provider/js/tsconfig.json
@@ -7,7 +7,14 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "types": ["node"],
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    // Map the package self-reference in src/pages-router/client.tsx to source,
+    // so `tsc --noEmit` doesn't depend on a built `dist/`. Bundler/runtime
+    // resolution is unaffected and still goes through package.json#exports.
+    // Add a new entry here for each additional self-referenced export.
+    "paths": {
+      "@spotify-confidence/openfeature-server-provider-local/react-client": ["./src/react/client.tsx"]
+    }
   },
   "include": ["src/**/*"]
 }

--- a/openfeature-provider/js/tsdown.config.ts
+++ b/openfeature-provider/js/tsdown.config.ts
@@ -63,4 +63,31 @@ export default defineConfig([
     platform: 'neutral',
     ...reactBase,
   },
+  // Pages Router: server-side helpers (withConfidence, resolveConfidence)
+  {
+    entry: { 'pages-router/server': './src/pages-router/server.ts' },
+    platform: 'neutral',
+    ...reactBase,
+    external: [...(reactBase.external || []), 'next', /^node:/],
+  },
+  // Pages Router: client wrapper used in _app.tsx. Externalize the
+  // package self-reference to react-client so we don't bundle a second copy
+  // of ConfidenceContext (which would silently break useFlag/useFlagDetails).
+  {
+    entry: { 'pages-router/client': './src/pages-router/client.tsx' },
+    platform: 'neutral',
+    ...reactBase,
+    external: [
+      ...(reactBase.external || []),
+      'next',
+      '@spotify-confidence/openfeature-server-provider-local/react-client',
+    ],
+  },
+  // Pages Router: applyHandler factory for the API route
+  {
+    entry: { 'pages-router/api': './src/pages-router/api.ts' },
+    platform: 'neutral',
+    ...reactBase,
+    external: [...(reactBase.external || []), 'next', /^node:/],
+  },
 ]);

--- a/openfeature-provider/js/yarn.lock
+++ b/openfeature-provider/js/yarn.lock
@@ -128,6 +128,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/runtime@npm:^1.7.0":
+  version: 1.10.0
+  resolution: "@emnapi/runtime@npm:1.10.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/953f14991d1aefb92ee6f8eb27dea725e484791a53a0cb5f47d9e0087b9a2c929ff2e92adf95af15d6ad456db6300c6b761ebf72b50a875b874a83520b3ba093
+  languageName: node
+  linkType: hard
+
 "@emnapi/wasi-threads@npm:1.1.0":
   version: 1.1.0
   resolution: "@emnapi/wasi-threads@npm:1.1.0"
@@ -319,6 +328,233 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@img/colour@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "@img/colour@npm:1.1.0"
+  checksum: 10c0/2ebea2c0bbaee73b99badcefa04e1e71d83f36e5369337d3121dca841f4569533c4e2faddda6d62dd247f0d5cca143711f9446c59bcce81e427ba433a7a94a17
+  languageName: node
+  linkType: hard
+
+"@img/sharp-darwin-arm64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-darwin-arm64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-darwin-arm64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-darwin-arm64":
+      optional: true
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-darwin-x64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-darwin-x64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-darwin-x64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-darwin-x64":
+      optional: true
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-darwin-arm64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-darwin-arm64@npm:1.2.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-darwin-x64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-darwin-x64@npm:1.2.4"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-arm64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linux-arm64@npm:1.2.4"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-arm@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linux-arm@npm:1.2.4"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-ppc64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linux-ppc64@npm:1.2.4"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-riscv64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linux-riscv64@npm:1.2.4"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-s390x@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linux-s390x@npm:1.2.4"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linux-x64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linux-x64@npm:1.2.4"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linuxmusl-arm64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linuxmusl-arm64@npm:1.2.4"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-libvips-linuxmusl-x64@npm:1.2.4":
+  version: 1.2.4
+  resolution: "@img/sharp-libvips-linuxmusl-x64@npm:1.2.4"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-arm64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linux-arm64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linux-arm64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-arm64":
+      optional: true
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-arm@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linux-arm@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linux-arm": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-arm":
+      optional: true
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-ppc64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linux-ppc64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linux-ppc64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-ppc64":
+      optional: true
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-riscv64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linux-riscv64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linux-riscv64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-riscv64":
+      optional: true
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-s390x@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linux-s390x@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linux-s390x": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-s390x":
+      optional: true
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linux-x64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linux-x64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linux-x64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linux-x64":
+      optional: true
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linuxmusl-arm64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linuxmusl-arm64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linuxmusl-arm64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linuxmusl-arm64":
+      optional: true
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-linuxmusl-x64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-linuxmusl-x64@npm:0.34.5"
+  dependencies:
+    "@img/sharp-libvips-linuxmusl-x64": "npm:1.2.4"
+  dependenciesMeta:
+    "@img/sharp-libvips-linuxmusl-x64":
+      optional: true
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@img/sharp-wasm32@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-wasm32@npm:0.34.5"
+  dependencies:
+    "@emnapi/runtime": "npm:^1.7.0"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-arm64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-win32-arm64@npm:0.34.5"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-ia32@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-win32-ia32@npm:0.34.5"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-x64@npm:0.34.5":
+  version: 0.34.5
+  resolution: "@img/sharp-win32-x64@npm:0.34.5"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@isaacs/cliui@npm:^8.0.2":
   version: 8.0.2
   resolution: "@isaacs/cliui@npm:8.0.2"
@@ -391,6 +627,69 @@ __metadata:
     "@emnapi/runtime": "npm:^1.5.0"
     "@tybys/wasm-util": "npm:^0.10.1"
   checksum: 10c0/8d29299933c57b6ead61f46fad5c3dfabc31e1356bbaf25c3a8ae57be0af0db0006a808f2c1bb16e28925e027f20e0856550dac94e015f56dd6ed53b38f9a385
+  languageName: node
+  linkType: hard
+
+"@next/env@npm:16.2.4":
+  version: 16.2.4
+  resolution: "@next/env@npm:16.2.4"
+  checksum: 10c0/4bf41f0da7cc97ca2a2f2b7f3fc81e14aba2afc280d32163b134b8f642b315fbabb5d9c224a783d8e759bbc73eedfc9acd048e772950395aa1e6290dd386d209
+  languageName: node
+  linkType: hard
+
+"@next/swc-darwin-arm64@npm:16.2.4":
+  version: 16.2.4
+  resolution: "@next/swc-darwin-arm64@npm:16.2.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@next/swc-darwin-x64@npm:16.2.4":
+  version: 16.2.4
+  resolution: "@next/swc-darwin-x64@npm:16.2.4"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm64-gnu@npm:16.2.4":
+  version: 16.2.4
+  resolution: "@next/swc-linux-arm64-gnu@npm:16.2.4"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm64-musl@npm:16.2.4":
+  version: 16.2.4
+  resolution: "@next/swc-linux-arm64-musl@npm:16.2.4"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-x64-gnu@npm:16.2.4":
+  version: 16.2.4
+  resolution: "@next/swc-linux-x64-gnu@npm:16.2.4"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-x64-musl@npm:16.2.4":
+  version: 16.2.4
+  resolution: "@next/swc-linux-x64-musl@npm:16.2.4"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@next/swc-win32-arm64-msvc@npm:16.2.4":
+  version: 16.2.4
+  resolution: "@next/swc-win32-arm64-msvc@npm:16.2.4"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@next/swc-win32-x64-msvc@npm:16.2.4":
+  version: 16.2.4
+  resolution: "@next/swc-win32-x64-msvc@npm:16.2.4"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -755,6 +1054,7 @@ __metadata:
     debug: "npm:^4.4.3"
     dotenv: "npm:^17.2.2"
     happy-dom: "npm:^20.3.4"
+    next: "npm:^16.0.0"
     prettier: "npm:^2.8.8"
     react: "npm:^19"
     react-dom: "npm:^19.2.3"
@@ -766,11 +1066,14 @@ __metadata:
   peerDependencies:
     "@openfeature/core": ^1.0.0
     debug: ^4.4.3
+    next: ">=13.0.0"
     react: ^18.0.0 || ^19.0.0
   peerDependenciesMeta:
     "@openfeature/core":
       optional: true
     debug:
+      optional: true
+    next:
       optional: true
     react:
       optional: true
@@ -783,6 +1086,15 @@ __metadata:
   peerDependencies:
     prettier: 2.x
   checksum: 10c0/d7033f9f3ab255b490084f72928d4df086f6a51bb6f88b0d3678a5a63e46fc58ad025a0a709f96d8ae91b82093d991d54ea6a48b7d3f2c7f3f747c1853b76532
+  languageName: node
+  linkType: hard
+
+"@swc/helpers@npm:0.5.15":
+  version: 0.5.15
+  resolution: "@swc/helpers@npm:0.5.15"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10c0/33002f74f6f885f04c132960835fdfc474186983ea567606db62e86acd0680ca82f34647e8e610f4e1e422d1c16fce729dde22cd3b797ab1fd9061a825dabca4
   languageName: node
   linkType: hard
 
@@ -1141,6 +1453,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"baseline-browser-mapping@npm:^2.9.19":
+  version: 2.10.27
+  resolution: "baseline-browser-mapping@npm:2.10.27"
+  bin:
+    baseline-browser-mapping: dist/cli.cjs
+  checksum: 10c0/8ebadaeeddc99367a1522661476d6c895b452a96023c6cef0576aecf8f5f6d37c91e6bde8fa8904cc11a32c5c6bc9df2030481504e50a5aed17e6c7f8bac3b5a
+  languageName: node
+  linkType: hard
+
 "birpc@npm:^2.5.0":
   version: 2.5.0
   resolution: "birpc@npm:2.5.0"
@@ -1184,6 +1505,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"caniuse-lite@npm:^1.0.30001579":
+  version: 1.0.30001791
+  resolution: "caniuse-lite@npm:1.0.30001791"
+  checksum: 10c0/53c8b5dad1c196a5e495405a7d2dc1db58aed9be02f60cf2a2e29d2c8d8cbb6c39beabf958d6aa191ab967ddcf49f22319452256b980bad1e271615acfe58940
+  languageName: node
+  linkType: hard
+
 "case-anything@npm:^2.1.13":
   version: 2.1.13
   resolution: "case-anything@npm:2.1.13"
@@ -1224,6 +1552,13 @@ __metadata:
   version: 3.0.0
   resolution: "chownr@npm:3.0.0"
   checksum: 10c0/43925b87700f7e3893296c8e9c56cc58f926411cce3a6e5898136daaf08f08b9a8eb76d37d3267e707d0dcc17aed2e2ebdf5848c0c3ce95cf910a919935c1b10
+  languageName: node
+  linkType: hard
+
+"client-only@npm:0.0.1":
+  version: 0.0.1
+  resolution: "client-only@npm:0.0.1"
+  checksum: 10c0/9d6cfd0c19e1c96a434605added99dff48482152af791ec4172fb912a71cff9027ff174efd8cdb2160cc7f377543e0537ffc462d4f279bc4701de3f2a3c4b358
   languageName: node
   linkType: hard
 
@@ -1300,6 +1635,13 @@ __metadata:
   bin:
     detect-libc: ./bin/detect-libc.js
   checksum: 10c0/4da0deae9f69e13bc37a0902d78bf7169480004b1fed3c19722d56cff578d16f0e11633b7fbf5fb6249181236c72e90024cbd68f0b9558ae06e281f47326d50d
+  languageName: node
+  linkType: hard
+
+"detect-libc@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "detect-libc@npm:2.1.2"
+  checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
   languageName: node
   linkType: hard
 
@@ -1975,10 +2317,79 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.6":
+  version: 3.3.12
+  resolution: "nanoid@npm:3.3.12"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10c0/ba142b7b39e11e80c16dd74b0365d407880c87c1cf7e1480956981ae940ee36060fa5b6f092cd1e315184dd19244c657bd017d03327bd3c62247d691c5e8edfb
+  languageName: node
+  linkType: hard
+
 "negotiator@npm:^1.0.0":
   version: 1.0.0
   resolution: "negotiator@npm:1.0.0"
   checksum: 10c0/4c559dd52669ea48e1914f9d634227c561221dd54734070791f999c52ed0ff36e437b2e07d5c1f6e32909fc625fe46491c16e4a8f0572567d4dd15c3a4fda04b
+  languageName: node
+  linkType: hard
+
+"next@npm:^16.0.0":
+  version: 16.2.4
+  resolution: "next@npm:16.2.4"
+  dependencies:
+    "@next/env": "npm:16.2.4"
+    "@next/swc-darwin-arm64": "npm:16.2.4"
+    "@next/swc-darwin-x64": "npm:16.2.4"
+    "@next/swc-linux-arm64-gnu": "npm:16.2.4"
+    "@next/swc-linux-arm64-musl": "npm:16.2.4"
+    "@next/swc-linux-x64-gnu": "npm:16.2.4"
+    "@next/swc-linux-x64-musl": "npm:16.2.4"
+    "@next/swc-win32-arm64-msvc": "npm:16.2.4"
+    "@next/swc-win32-x64-msvc": "npm:16.2.4"
+    "@swc/helpers": "npm:0.5.15"
+    baseline-browser-mapping: "npm:^2.9.19"
+    caniuse-lite: "npm:^1.0.30001579"
+    postcss: "npm:8.4.31"
+    sharp: "npm:^0.34.5"
+    styled-jsx: "npm:5.1.6"
+  peerDependencies:
+    "@opentelemetry/api": ^1.1.0
+    "@playwright/test": ^1.51.1
+    babel-plugin-react-compiler: "*"
+    react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+    react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+    sass: ^1.3.0
+  dependenciesMeta:
+    "@next/swc-darwin-arm64":
+      optional: true
+    "@next/swc-darwin-x64":
+      optional: true
+    "@next/swc-linux-arm64-gnu":
+      optional: true
+    "@next/swc-linux-arm64-musl":
+      optional: true
+    "@next/swc-linux-x64-gnu":
+      optional: true
+    "@next/swc-linux-x64-musl":
+      optional: true
+    "@next/swc-win32-arm64-msvc":
+      optional: true
+    "@next/swc-win32-x64-msvc":
+      optional: true
+    sharp:
+      optional: true
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    "@playwright/test":
+      optional: true
+    babel-plugin-react-compiler:
+      optional: true
+    sass:
+      optional: true
+  bin:
+    next: dist/bin/next
+  checksum: 10c0/81dc1ef30141891dc5cc999a0a6210c68305b585b3a7508799767572a9fb7e4c7dcb5a50f5fa3fabadf6a46c2273405360b1d6f17f89edd891da1746ae31c186
   languageName: node
   linkType: hard
 
@@ -2058,7 +2469,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:1.1.1, picocolors@npm:^1.1.1":
+"picocolors@npm:1.1.1, picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
@@ -2069,6 +2480,17 @@ __metadata:
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
+  languageName: node
+  linkType: hard
+
+"postcss@npm:8.4.31":
+  version: 8.4.31
+  resolution: "postcss@npm:8.4.31"
+  dependencies:
+    nanoid: "npm:^3.3.6"
+    picocolors: "npm:^1.0.0"
+    source-map-js: "npm:^1.0.2"
+  checksum: 10c0/748b82e6e5fc34034dcf2ae88ea3d11fd09f69b6c50ecdd3b4a875cfc7cdca435c958b211e2cb52355422ab6fccb7d8f2f2923161d7a1b281029e4a913d59acf
   languageName: node
   linkType: hard
 
@@ -2374,6 +2796,99 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.7.3":
+  version: 7.7.4
+  resolution: "semver@npm:7.7.4"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
+  languageName: node
+  linkType: hard
+
+"sharp@npm:^0.34.5":
+  version: 0.34.5
+  resolution: "sharp@npm:0.34.5"
+  dependencies:
+    "@img/colour": "npm:^1.0.0"
+    "@img/sharp-darwin-arm64": "npm:0.34.5"
+    "@img/sharp-darwin-x64": "npm:0.34.5"
+    "@img/sharp-libvips-darwin-arm64": "npm:1.2.4"
+    "@img/sharp-libvips-darwin-x64": "npm:1.2.4"
+    "@img/sharp-libvips-linux-arm": "npm:1.2.4"
+    "@img/sharp-libvips-linux-arm64": "npm:1.2.4"
+    "@img/sharp-libvips-linux-ppc64": "npm:1.2.4"
+    "@img/sharp-libvips-linux-riscv64": "npm:1.2.4"
+    "@img/sharp-libvips-linux-s390x": "npm:1.2.4"
+    "@img/sharp-libvips-linux-x64": "npm:1.2.4"
+    "@img/sharp-libvips-linuxmusl-arm64": "npm:1.2.4"
+    "@img/sharp-libvips-linuxmusl-x64": "npm:1.2.4"
+    "@img/sharp-linux-arm": "npm:0.34.5"
+    "@img/sharp-linux-arm64": "npm:0.34.5"
+    "@img/sharp-linux-ppc64": "npm:0.34.5"
+    "@img/sharp-linux-riscv64": "npm:0.34.5"
+    "@img/sharp-linux-s390x": "npm:0.34.5"
+    "@img/sharp-linux-x64": "npm:0.34.5"
+    "@img/sharp-linuxmusl-arm64": "npm:0.34.5"
+    "@img/sharp-linuxmusl-x64": "npm:0.34.5"
+    "@img/sharp-wasm32": "npm:0.34.5"
+    "@img/sharp-win32-arm64": "npm:0.34.5"
+    "@img/sharp-win32-ia32": "npm:0.34.5"
+    "@img/sharp-win32-x64": "npm:0.34.5"
+    detect-libc: "npm:^2.1.2"
+    semver: "npm:^7.7.3"
+  dependenciesMeta:
+    "@img/sharp-darwin-arm64":
+      optional: true
+    "@img/sharp-darwin-x64":
+      optional: true
+    "@img/sharp-libvips-darwin-arm64":
+      optional: true
+    "@img/sharp-libvips-darwin-x64":
+      optional: true
+    "@img/sharp-libvips-linux-arm":
+      optional: true
+    "@img/sharp-libvips-linux-arm64":
+      optional: true
+    "@img/sharp-libvips-linux-ppc64":
+      optional: true
+    "@img/sharp-libvips-linux-riscv64":
+      optional: true
+    "@img/sharp-libvips-linux-s390x":
+      optional: true
+    "@img/sharp-libvips-linux-x64":
+      optional: true
+    "@img/sharp-libvips-linuxmusl-arm64":
+      optional: true
+    "@img/sharp-libvips-linuxmusl-x64":
+      optional: true
+    "@img/sharp-linux-arm":
+      optional: true
+    "@img/sharp-linux-arm64":
+      optional: true
+    "@img/sharp-linux-ppc64":
+      optional: true
+    "@img/sharp-linux-riscv64":
+      optional: true
+    "@img/sharp-linux-s390x":
+      optional: true
+    "@img/sharp-linux-x64":
+      optional: true
+    "@img/sharp-linuxmusl-arm64":
+      optional: true
+    "@img/sharp-linuxmusl-x64":
+      optional: true
+    "@img/sharp-wasm32":
+      optional: true
+    "@img/sharp-win32-arm64":
+      optional: true
+    "@img/sharp-win32-ia32":
+      optional: true
+    "@img/sharp-win32-x64":
+      optional: true
+  checksum: 10c0/fd79e29df0597a7d5704b8461c51f944ead91a5243691697be6e8243b966402beda53ddc6f0a53b96ea3cb8221f0b244aa588114d3ebf8734fb4aefd41ab802f
+  languageName: node
+  linkType: hard
+
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -2432,7 +2947,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.2.0, source-map-js@npm:^1.2.1":
+"source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.0, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
@@ -2508,6 +3023,22 @@ __metadata:
   dependencies:
     js-tokens: "npm:^9.0.1"
   checksum: 10c0/d81657f84aba42d4bbaf2a677f7e7f34c1f3de5a6726db8bc1797f9c0b303ba54d4660383a74bde43df401cf37cce1dff2c842c55b077a4ceee11f9e31fba828
+  languageName: node
+  linkType: hard
+
+"styled-jsx@npm:5.1.6":
+  version: 5.1.6
+  resolution: "styled-jsx@npm:5.1.6"
+  dependencies:
+    client-only: "npm:0.0.1"
+  peerDependencies:
+    react: ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    babel-plugin-macros:
+      optional: true
+  checksum: 10c0/ace50e7ea5ae5ae6a3b65a50994c51fca6ae7df9c7ecfd0104c36be0b4b3a9c5c1a2374d16e2a11e256d0b20be6d47256d768ecb4f91ab390f60752a075780f5
   languageName: node
   linkType: hard
 
@@ -2678,7 +3209,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.4.0":
+"tslib@npm:^2.4.0, tslib@npm:^2.8.0":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62


### PR DESCRIPTION
## Summary

Adds three subexports under `./pages-router/*` for the Next.js Pages Router, parallel to the existing `react-server`/`react-client` pair for App Router:

- **`pages-router/server`** — `withConfidence(config, gssp?)` HOC that resolves the flag bundle in `getServerSideProps` (no exposure) and merges it into `pageProps`. Plus a low-level `resolveConfidence` helper.
- **`pages-router/client`** — `<ConfidencePagesProvider>` for `_app.tsx`. The existing `useFlag` / `useFlagDetails` from `react-client` work unchanged.
- **`pages-router/api`** — `applyHandler({ providerName? }?)` factory for the `/api/confidence/apply` POST route the client uses to log exposure.

The resolve token is sealed with AES-256-GCM (key from `CONFIDENCE_TOKEN_KEY` env var) before reaching the client, since Pages Router has no encrypted-closure equivalent to App Router server actions. The apply route opens it server-side.

`README-REACT.md` gets a new "Next.js Pages Router" section. The App Router quick-start was also moved to `instrumentation.ts` since that's router-agnostic and avoids the build-time side-effect issue with top-level-await setup files.

## Test plan

- [ ] `yarn typecheck` clean
- [ ] `yarn test` — 7 token tests + 6 apply-handler tests pass
- [ ] `yarn build` emits `dist/pages-router/{server,client,api}.{js,d.ts}`
- [ ] Existing `react-server` / `react-client` builds unchanged
- [ ] Verified end-to-end against a Pages Router demo app (server-side resolve → client hook reads → apply route fires exposure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)