### PR TITLE
feat(cloudflare): add Wrangler extension hooks to deployer

### DIFF
--- a/confidence-cloudflare-resolver/deployer/README.md
+++ b/confidence-cloudflare-resolver/deployer/README.md
@@ -58,6 +58,57 @@ The deployer automatically:
 | `FORCE_DEPLOY`                       | Force re-deploy regardless of state changes                                                                                                       |
 | `NO_DEPLOY`                          | Build only, skip deployment                                                                                                                       |
 | `WORKER_NAME_PREFIX`                 | Prefix for worker and queue names. Deploys as `<prefix>-confidence-cloudflare-resolver` with queue `<prefix>-flag-logs-queue` (auto-created)     |
+| `WRANGLER_CONFIG_APPEND_FILE`        | Path to a file containing TOML to append to the generated `wrangler.toml`                                                                          |
+| `WRANGLER_DEPLOY_TAG`                | Value passed to `wrangler deploy --tag`                                                                                                           |
+| `WRANGLER_DEPLOY_MESSAGE`            | Value passed to `wrangler deploy --message`                                                                                                       |
+| `WRANGLER_DEPLOY_ARGS`               | Additional newline-separated arguments passed to `wrangler deploy`                                                                                |
+| `WRANGLER_DEPLOY_ARGS_FILE`          | Path to a file containing additional `wrangler deploy` arguments, one argument per line                                                           |
+
+### Extending Wrangler Configuration
+
+Use `WRANGLER_CONFIG_APPEND_FILE` when your Cloudflare account needs configuration that is not managed by the deployer, such as observability destinations or tail consumers.
+
+Example:
+
+`wrangler-extra.toml`
+
+```toml
+[[tail_consumers]]
+service = "my-tail-worker"
+
+[observability.logs]
+enabled = true
+destinations = ["otel-gateway-logs"]
+head_sampling_rate = 1.0
+```
+
+```bash
+docker run -it \
+    -v "$PWD/wrangler-extra.toml:/tmp/wrangler-extra.toml:ro" \
+    -e CLOUDFLARE_API_TOKEN='your-cloudflare-api-token' \
+    -e CONFIDENCE_CLIENT_SECRET='your-confidence-client-secret' \
+    -e WRANGLER_CONFIG_APPEND_FILE='/tmp/wrangler-extra.toml' \
+    -e WRANGLER_DEPLOY_TAG='production-2026-05-05' \
+    -e WRANGLER_DEPLOY_MESSAGE='Deploy resolver state with tail worker logs' \
+    ghcr.io/spotify/confidence-cloudflare-deployer:latest
+```
+
+The snippet is appended after the deployer has written its generated settings. To avoid top-level keys being parsed inside an existing table, the first non-comment line must be a TOML table header such as `[[tail_consumers]]` or `[observability.logs]`.
+
+### Extending Wrangler Deploy
+
+Use `WRANGLER_DEPLOY_TAG` and `WRANGLER_DEPLOY_MESSAGE` to label the deployed Worker version and deployment in Cloudflare.
+
+```bash
+docker run -it \
+    -e CLOUDFLARE_API_TOKEN='your-cloudflare-api-token' \
+    -e CONFIDENCE_CLIENT_SECRET='your-confidence-client-secret' \
+    -e WRANGLER_DEPLOY_TAG='production-2026-05-05' \
+    -e WRANGLER_DEPLOY_MESSAGE='Update embedded resolver state' \
+    ghcr.io/spotify/confidence-cloudflare-deployer:latest
+```
+
+For less common Wrangler deploy flags, use `WRANGLER_DEPLOY_ARGS` or `WRANGLER_DEPLOY_ARGS_FILE` with one argument per line. Prefer `WRANGLER_DEPLOY_TAG` and `WRANGLER_DEPLOY_MESSAGE` for tags and messages so values may contain spaces safely.
 
 ## Service Binding vs HTTP Calls
 

--- a/confidence-cloudflare-resolver/deployer/script.sh
+++ b/confidence-cloudflare-resolver/deployer/script.sh
@@ -14,6 +14,12 @@ CONFIDENCE_CLIENT_SECRET=${CONFIDENCE_CLIENT_SECRET:=}
 NO_DEPLOY=${NO_DEPLOY:=}
 FORCE_DEPLOY=${FORCE_DEPLOY:=}
 WORKER_NAME_PREFIX=${WORKER_NAME_PREFIX:=}
+WRANGLER_CONFIG_APPEND_FILE=${WRANGLER_CONFIG_APPEND_FILE:=}
+WRANGLER_DEPLOY_ARGS=${WRANGLER_DEPLOY_ARGS:=}
+WRANGLER_DEPLOY_ARGS_FILE=${WRANGLER_DEPLOY_ARGS_FILE:=}
+WRANGLER_DEPLOY_TAG=${WRANGLER_DEPLOY_TAG:=}
+WRANGLER_DEPLOY_MESSAGE=${WRANGLER_DEPLOY_MESSAGE:=}
+INITIAL_WORKDIR="$(pwd)"
 
 # CDN base URL for fetching resolver state
 CDN_BASE_URL="https://confidence-resolver-state-cdn.spotifycdn.com"
@@ -106,7 +112,6 @@ mkdir -p data
 RESPONSE_FILE="data/resolver_state_current.pb"
 ETAG_TOML=""
 ALLOWED_ORIGIN_TOML=""
-VERSION_TOML=""
 CLIENT_SECRET_TOML=""
 
 EXTRA_HEADER=()
@@ -226,6 +231,74 @@ check_file() {
     fi
 }
 
+resolve_input_path() {
+    local input_path="$1"
+
+    case "$input_path" in
+        /*) printf '%s\n' "$input_path" ;;
+        *) printf '%s/%s\n' "$INITIAL_WORKDIR" "$input_path" ;;
+    esac
+}
+
+validate_wrangler_config_append() {
+    local source_name="$1"
+    local content="$2"
+
+    while IFS= read -r line; do
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        if [ -z "$line" ] || [[ "$line" == \#* ]]; then
+            continue
+        fi
+        if [[ "$line" == \[* ]]; then
+            return
+        fi
+        echo "❌ ${source_name} must start with a TOML table header such as [[tail_consumers]] or [observability.logs]" >&2
+        echo "   Top-level keys cannot be appended safely after existing tables in wrangler.toml." >&2
+        exit 1
+    done <<< "$content"
+}
+
+append_wrangler_config() {
+    local source_name="$1"
+    local content="$2"
+
+    if [ -z "$content" ]; then
+        return
+    fi
+
+    validate_wrangler_config_append "$source_name" "$content"
+
+    {
+        printf '\n'
+        printf '# Appended by confidence-cloudflare-deployer from %s\n' "$source_name"
+        printf '%s\n' "$content"
+    } >> wrangler.toml
+
+    echo "✅ Appended Wrangler config from ${source_name}"
+}
+
+add_wrangler_deploy_args_from_lines() {
+    local source_name="$1"
+    local content="$2"
+
+    if [ -z "$content" ]; then
+        return
+    fi
+
+    local count=0
+    while IFS= read -r arg; do
+        if [ -n "$arg" ]; then
+            WRANGLER_DEPLOY_ARGS_ARRAY+=("$arg")
+            count=$((count + 1))
+        fi
+    done <<< "$content"
+
+    if [ "$count" -gt 0 ]; then
+        echo "✅ Added ${count} Wrangler deploy arg(s) from ${source_name}"
+    fi
+}
+
 # Verify all required files
 check_file "data/resolver_state_current.pb"
 # Note: encryption_key may be empty, so we just check it exists
@@ -307,11 +380,6 @@ if [ -n "$CONFIDENCE_RESOLVER_ALLOWED_ORIGIN" ]; then
     ALLOWED_ORIGIN_TOML=$(printf '%s' "$CONFIDENCE_RESOLVER_ALLOWED_ORIGIN" | sed 's/\\/\\\\/g; s/\"/\\\"/g')
 fi
 
-# Prepare RESOLVER_VERSION for TOML
-if [ -n "$DEPLOYER_VERSION" ]; then
-    VERSION_TOML=$(printf '%s' "$DEPLOYER_VERSION" | sed 's/\\/\\\\/g; s/\"/\\\"/g')
-fi
-
 # Prepare CONFIDENCE_CLIENT_SECRET for TOML (escape quotes and backslashes)
 if [ -n "$CONFIDENCE_CLIENT_SECRET" ]; then
     CLIENT_SECRET_TOML=$(printf '%s' "$CONFIDENCE_CLIENT_SECRET" | sed 's/\\/\\\\/g; s/\"/\\\"/g')
@@ -352,6 +420,15 @@ if [ -n "$ALLOWED_ORIGIN_TOML" ] || [ -n "$ETAG_TOML" ] || [ -n "$DEPLOYER_VERSI
     fi
 fi
 
+if [ -n "$WRANGLER_CONFIG_APPEND_FILE" ]; then
+    WRANGLER_CONFIG_APPEND_FILE_PATH=$(resolve_input_path "$WRANGLER_CONFIG_APPEND_FILE")
+    if [ ! -f "$WRANGLER_CONFIG_APPEND_FILE_PATH" ]; then
+        echo "❌ WRANGLER_CONFIG_APPEND_FILE does not exist: $WRANGLER_CONFIG_APPEND_FILE_PATH" >&2
+        exit 1
+    fi
+    append_wrangler_config "WRANGLER_CONFIG_APPEND_FILE" "$(cat "$WRANGLER_CONFIG_APPEND_FILE_PATH")"
+fi
+
 # Build the worker after state is downloaded
 export CARGO_TARGET_DIR=/workspace/target
 export PATH="/usr/local/cargo/bin:$PATH"
@@ -367,14 +444,41 @@ echo "🔧 Checking wasm-bindgen..."
 which wasm-bindgen || echo "wasm-bindgen not in PATH"
 wasm-bindgen --version || echo "wasm-bindgen version check failed"
 echo "🔧 PATH: $PATH"
-echo "🔧 CARGO_HOME: $CARGO_HOME"
-ls -la /usr/local/cargo/bin/ | grep wasm || echo "no wasm tools in cargo bin"
+echo "🔧 CARGO_HOME: ${CARGO_HOME:-}"
+wasm_tools=(/usr/local/cargo/bin/*wasm*)
+if [ -e "${wasm_tools[0]}" ]; then
+    printf '%s\n' "${wasm_tools[@]}"
+else
+    echo "no wasm tools in cargo bin"
+fi
 
 RUSTFLAGS='--cfg getrandom_backend="wasm_js"' worker-build --release
 
+WRANGLER_DEPLOY_ARGS_ARRAY=()
+if [ -n "$WRANGLER_DEPLOY_TAG" ]; then
+    WRANGLER_DEPLOY_ARGS_ARRAY+=(--tag "$WRANGLER_DEPLOY_TAG")
+    echo "✅ Using Wrangler deploy tag"
+fi
+
+if [ -n "$WRANGLER_DEPLOY_MESSAGE" ]; then
+    WRANGLER_DEPLOY_ARGS_ARRAY+=(--message "$WRANGLER_DEPLOY_MESSAGE")
+    echo "✅ Using Wrangler deploy message"
+fi
+
+if [ -n "$WRANGLER_DEPLOY_ARGS_FILE" ]; then
+    WRANGLER_DEPLOY_ARGS_FILE_PATH=$(resolve_input_path "$WRANGLER_DEPLOY_ARGS_FILE")
+    if [ ! -f "$WRANGLER_DEPLOY_ARGS_FILE_PATH" ]; then
+        echo "❌ WRANGLER_DEPLOY_ARGS_FILE does not exist: $WRANGLER_DEPLOY_ARGS_FILE_PATH" >&2
+        exit 1
+    fi
+    add_wrangler_deploy_args_from_lines "WRANGLER_DEPLOY_ARGS_FILE" "$(cat "$WRANGLER_DEPLOY_ARGS_FILE_PATH")"
+fi
+
+add_wrangler_deploy_args_from_lines "WRANGLER_DEPLOY_ARGS" "$WRANGLER_DEPLOY_ARGS"
+
 # only deploy if NO_DEPLOY is not set
 if test -z "$NO_DEPLOY"; then
-     wrangler deploy
+     wrangler deploy "${WRANGLER_DEPLOY_ARGS_ARRAY[@]}"
 else
      echo "NO_DEPLOY is set, skipping deploy"
 fi


### PR DESCRIPTION
## Summary
- add `WRANGLER_CONFIG_APPEND_FILE` so deployer users can append opt-in Wrangler TOML such as `tail_consumers` and observability destinations without forking the generated config
- require appended TOML to start with a table header, avoiding accidental top-level keys being parsed inside an existing table
- add `WRANGLER_DEPLOY_TAG` / `WRANGLER_DEPLOY_MESSAGE` for Cloudflare Worker version/deployment labels
- add newline-based `WRANGLER_DEPLOY_ARGS` / `WRANGLER_DEPLOY_ARGS_FILE` as an escape hatch for less common `wrangler deploy` flags
- harden deployer debug output for unset `CARGO_HOME` and clean up ShellCheck warnings in the touched script

## Motivation
The deployer owns the generated `wrangler.toml`, which makes it hard for users to attach account-specific observability pipelines such as Tail Workers or OTEL log destinations. The file-based append hook keeps the deployer closed to provider-specific wiring while allowing users to extend Wrangler config in one predictable way.

## Testing
- `bash -n confidence-cloudflare-resolver/deployer/script.sh`
- `shellcheck confidence-cloudflare-resolver/deployer/script.sh`
- temp smoke test with local resolver state plus stubbed `curl`/`worker-build`/`wrangler`, verifying relative append file resolution, appended `[[tail_consumers]]` config, and `wrangler deploy --tag ... --message ... --minify --keep-vars` arguments