### PR TITLE
fix: correct rust-guest path in release-please config and add force-deploy escape hatch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      force_cloudflare_deploy:
+        description: 'Force publish the cloudflare deployer image (use when release tag was created but publish job was skipped)'
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -38,7 +44,7 @@ jobs:
 
   publish-cloudflare-deployer-image:
     needs: release
-    if: ${{ needs.release.outputs.cloudflare_resolver_release_created == 'true' }}
+    if: ${{ needs.release.outputs.cloudflare_resolver_release_created == 'true' || inputs.force_cloudflare_deploy == true }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -24,6 +24,7 @@
       "initial-version": "0.1.0"
     },
     "wasm/rust-guest": {
+      "path": "wasm/rust-guest",
       "release-type": "rust",
       "changelog-path": "CHANGELOG.md",
       "initial-version": "0.1.0"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,8 +23,7 @@
       "changelog-path": "CHANGELOG.md",
       "initial-version": "0.1.0"
     },
-    "rust-guest": {
-      "path": "wasm/rust-guest",
+    "wasm/rust-guest": {
       "release-type": "rust",
       "changelog-path": "CHANGELOG.md",
       "initial-version": "0.1.0"


### PR DESCRIPTION
## Summary

- Fixes a key/path mismatch in `release-please-config.json` for `rust-guest`: the package key was `rust-guest` but the manifest and actual directory are both under `wasm/rust-guest`. This caused release-please to scan all 500 commits on every run looking for a release that would never be found, eventually hitting a GitHub API timeout.
- Adds a `workflow_dispatch` trigger with a `force_cloudflare_deploy` boolean input to `release-please.yml`, so the cloudflare deployer image can be manually re-published when a release tag was created but the publish job was skipped (e.g. due to a timeout).

## Test plan

- [ ] Merge this PR
- [ ] Run `gh workflow run release-please.yml --field force_cloudflare_deploy=true` to publish the missing `confidence-cloudflare-resolver-v0.9.0` deployer image
- [ ] Verify the image appears in GHCR tagged as `confidence-cloudflare-resolver-v0.9.0` and `latest`

Made with [Cursor](https://cursor.com)