### PR TITLE
fix(java): skip wasm setResolverState when flag state is unchanged

### DIFF
--- a/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProvider.java
+++ b/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProvider.java
@@ -65,6 +65,7 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
   private final AtomicReference<ProviderState> state =
       new AtomicReference<>(ProviderState.NOT_READY);
   private volatile boolean initialized = false;
+  private volatile byte[] lastStateBytes = null;
   private static final Sdk SDK =
       Sdk.newBuilder().setId(SdkId.SDK_ID_JAVA_LOCAL_PROVIDER).setVersion(Version.VERSION).build();
 
@@ -237,12 +238,19 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
             if (!accountIdRef.get().isEmpty()) {
               if (!initialized) {
                 resolver.setResolverState(resolverStateProtobuf.get(), accountIdRef.get(), SDK);
+                lastStateBytes = resolverStateProtobuf.get();
                 initialized = true;
                 this.state.set(ProviderState.READY);
                 log.info("Provider recovered and is now READY");
               } else {
-                // State refresh + full log flush
-                resolver.setResolverState(resolverStateProtobuf.get(), accountIdRef.get(), SDK);
+                // Only push state into the wasm instances when it actually changed — the wasm
+                // execution inside setResolverState is expensive (runs across all pool slots).
+                final byte[] newState = resolverStateProtobuf.get();
+                if (!java.util.Arrays.equals(newState, lastStateBytes)) {
+                  resolver.setResolverState(newState, accountIdRef.get(), SDK);
+                  lastStateBytes = newState;
+                }
+                // Always flush logs regardless of state change.
                 resolver.flushAllLogs();
               }
             }


### PR DESCRIPTION
The periodic state refresh unconditionally pushed the state blob through all wasm pool instances every poll interval (default 15s), even when the state hadn't changed. Each setResolverState call runs wasm execution across all pool slots — expensive CPU work for a no-op when the flag definitions haven't evolved.

Compare the new state bytes with the previous via Arrays.equals and skip setResolverState when unchanged. Log flushing still runs every cycle regardless.