### PR TITLE
fix(cloudflare): prevent 503 from unsafe JS casts and queue flooding

### DIFF
--- a/confidence-cloudflare-resolver/src/lib.rs
+++ b/confidence-cloudflare-resolver/src/lib.rs
@@ -14,6 +14,7 @@ use prost::Message;
 use serde_json::from_slice;
 use serde_json::json;
 use std::cell::RefCell;
+use wasm_bindgen::JsCast;
 
 use confidence::flags::resolver::v1::{ApplyFlagsRequest, ApplyFlagsResponse, ResolveFlagsRequest};
 use confidence_resolver::proto::confidence::flags::resolver::v1::{
@@ -167,8 +168,6 @@ pub async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
         return Response::ok("")?.with_cors_headers(&allowed_origin_env);
     }
 
-    FLAG_LOG.with(|f| *f.borrow_mut() = Some(WriteFlagLogsRequest::default()));
-
     let state = &RESOLVER_STATE;
     let router = Router::new();
 
@@ -218,6 +217,7 @@ pub async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
                 let path = ctx.param("path").unwrap();
                 match path.as_str() {
                     "flags:resolve" => {
+                        FLAG_LOG.with(|f| *f.borrow_mut() = Some(WriteFlagLogsRequest::default()));
                         let body_bytes: Vec<u8> = req.bytes().await?;
                         let mut resolver_request: ResolveFlagsRequest =
                             match from_slice(&body_bytes) {
@@ -286,11 +286,6 @@ pub async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
                             }
                         };
 
-                        // Unfreeze timer: scheduler.wait(0) yields to the
-                        // runtime with zero delay, advancing the clock.
-                        // If CF removes or changes the scheduler API, all
-                        // lookups fall through gracefully: elapsed_us is None,
-                        // the resolve still succeeds, we just lose latency data.
                         let elapsed_us = {
                             let scheduler = js_sys::Reflect::get(
                                 &js_sys::global(), &wasm_bindgen::JsValue::from_str("scheduler")
@@ -299,12 +294,12 @@ pub async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
                                 let wait = js_sys::Reflect::get(
                                     &scheduler, &wasm_bindgen::JsValue::from_str("wait")
                                 ).unwrap_or(wasm_bindgen::JsValue::UNDEFINED);
-                                if let Ok(promise) = js_sys::Function::from(wait)
-                                    .call1(&scheduler, &wasm_bindgen::JsValue::from(0))
-                                {
-                                    let _ = wasm_bindgen_futures::JsFuture::from(
-                                        js_sys::Promise::from(promise)
-                                    ).await;
+                                if let Ok(func) = wait.dyn_into::<js_sys::Function>() {
+                                    if let Ok(ret) = func.call1(&scheduler, &wasm_bindgen::JsValue::from(0)) {
+                                        if let Ok(promise) = ret.dyn_into::<js_sys::Promise>() {
+                                            let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+                                        }
+                                    }
                                 }
                                 Some(((js_sys::Date::now() - t0) * 1000.0).max(0.0) as u32)
                             } else {
@@ -323,6 +318,7 @@ pub async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
                         resp
                     }
                     "flags:apply" => {
+                        FLAG_LOG.with(|f| *f.borrow_mut() = Some(WriteFlagLogsRequest::default()));
                         let body_bytes: Vec<u8> = req.bytes().await?;
                         let apply_flag_req: ApplyFlagsRequest = match from_slice(&body_bytes) {
                             Ok(req) => req,


### PR DESCRIPTION
## Summary

Fixes a regression from #400 (telemetry) that causes **503 Internal Server Error** on `POST /v1/flags:resolve` for Cloudflare resolver customers.

### Root cause

1. **Unsafe unchecked JS casts crash the Worker after a successful resolve.** The `scheduler.wait(0)` latency measurement code used `js_sys::Function::from(wait)` and `js_sys::Promise::from(promise)` — both perform `unchecked_from_js` which is undefined behavior when the JS value is not the expected type. This runs *after* the resolve succeeds but *before* the HTTP response is returned, which explains why the Confidence dashboard shows resolves happening while the client gets 503.

2. **Every request floods the queue with empty messages.** `FLAG_LOG` was initialized before routing, so GET routes (`/metrics`, `/v1/state:etag`), health checks, and unknown paths all queued an empty `WriteFlagLogsRequest`.

### Fixes

- Replace `js_sys::Function::from()` / `js_sys::Promise::from()` with safe `dyn_into::<Function>()` / `dyn_into::<Promise>()` — failed casts are silently skipped (we lose latency data but the resolve still succeeds)
- Move `FLAG_LOG` initialization from before routing into only the `flags:resolve` and `flags:apply` handlers — GET routes no longer touch the queue

## Test plan

- [ ] Deploy to a staging Cloudflare Worker and verify `POST /v1/flags:resolve` returns 200 with valid flag values
- [ ] Verify `/metrics` and `/v1/state:etag` GET routes do not produce queue messages
- [ ] Verify telemetry latency data is still collected on successful resolves
- [ ] Confirm no 503 errors in Cloudflare dashboard after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)