### PR TITLE
test: migrate to new Confidence workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Prepare secrets
+        run: echo "${{ secrets.CONFIDENCE_CLIENT_SECRET }}" > /tmp/confidence_client_secret.txt
+
       - name: Build and test everything (PR)
         if: github.event_name != 'push'
         uses: docker/build-push-action@v7
@@ -37,6 +40,8 @@ jobs:
           platforms: linux/arm64
           push: false
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cache:main
+          secret-files: |
+            confidence_client_secret=/tmp/confidence_client_secret.txt
 
       - name: Build and test everything (Push - updates cache)
         if: github.event_name == 'push'
@@ -47,3 +52,5 @@ jobs:
           push: false
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cache:main
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/cache:main,mode=max
+          secret-files: |
+            confidence_client_secret=/tmp/confidence_client_secret.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -319,15 +319,19 @@ COPY wasm/resolver_state.pb ../../../wasm/resolver_state.pb
 COPY openfeature-provider/js/prettier.config.cjs ./
 COPY openfeature-provider/js/.prettierignore ./
 
-RUN make test
+RUN --mount=type=secret,id=confidence_client_secret \
+    CONFIDENCE_CLIENT_SECRET=$(cat /run/secrets/confidence_client_secret) \
+    make test
 
 # ==============================================================================
 # E2E Test OpenFeature Provider (requires credentials)
 # ==============================================================================
 FROM openfeature-provider-js.test AS openfeature-provider-js.test_e2e
 
-# Run e2e tests with secrets mounted as .env.test file
-RUN make test-e2e
+# Run e2e tests with secrets mounted
+RUN --mount=type=secret,id=confidence_client_secret \
+    CONFIDENCE_CLIENT_SECRET=$(cat /run/secrets/confidence_client_secret) \
+    make test-e2e
 
 # ==============================================================================
 # Build OpenFeature Provider
@@ -444,7 +448,9 @@ RUN make build
 # ==============================================================================
 FROM openfeature-provider-go.build AS openfeature-provider-go.test
 
-RUN make test
+RUN --mount=type=secret,id=confidence_client_secret \
+    CONFIDENCE_CLIENT_SECRET=$(cat /run/secrets/confidence_client_secret) \
+    make test
 
 # ==============================================================================
 # Lint OpenFeature Provider (Go)
@@ -567,7 +573,9 @@ RUN make test
 # ==============================================================================
 FROM openfeature-provider-python.test AS openfeature-provider-python.test_e2e
 
-RUN make test-e2e
+RUN --mount=type=secret,id=confidence_client_secret \
+    CONFIDENCE_CLIENT_SECRET=$(cat /run/secrets/confidence_client_secret) \
+    make test-e2e
 
 # ==============================================================================
 # Lint OpenFeature Provider (Python)
@@ -613,7 +621,9 @@ RUN make test
 FROM openfeature-provider-rust.build AS openfeature-provider-rust.test_e2e
 
 WORKDIR /workspace/openfeature-provider/rust
-RUN make test-e2e
+RUN --mount=type=secret,id=confidence_client_secret \
+    CONFIDENCE_CLIENT_SECRET=$(cat /run/secrets/confidence_client_secret) \
+    make test-e2e
 
 # ==============================================================================
 # OpenFeature Provider (Rust) - Lint
@@ -690,15 +700,18 @@ RUN make build
 # ==============================================================================
 FROM openfeature-provider-java.build AS openfeature-provider-java.test
 
-RUN make test
+RUN --mount=type=secret,id=confidence_client_secret \
+    CONFIDENCE_CLIENT_SECRET=$(cat /run/secrets/confidence_client_secret) \
+    make test
 
 # ==============================================================================
 # E2E Test OpenFeature Provider (Java) (requires credentials)
 # ==============================================================================
 FROM openfeature-provider-java.test AS openfeature-provider-java.test_e2e
 
-# Run e2e tests with secrets mounted as .env.test file
-RUN make test-e2e
+RUN --mount=type=secret,id=confidence_client_secret \
+    CONFIDENCE_CLIENT_SECRET=$(cat /run/secrets/confidence_client_secret) \
+    make test-e2e
 
 # ==============================================================================
 # Publish OpenFeature Provider (Java) to Maven Central

--- a/openfeature-provider/go/confidence/e2e_test.go
+++ b/openfeature-provider/go/confidence/e2e_test.go
@@ -2,6 +2,7 @@ package confidence
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/open-feature/go-sdk/openfeature"
@@ -9,8 +10,9 @@ import (
 
 // End-to-end tests that verify WriteFlagLogs successfully sends to the real backend.
 
+var e2eClientSecret = os.Getenv("CONFIDENCE_CLIENT_SECRET")
+
 const (
-	e2eClientSecret         = "Ip7lGcBeGA4Le9MI8md4i5LkUOnLnyFx"
 	e2eIncludedTargetingKey = "user-a"
 	e2eExcludedTargetingKey = "user-x"
 )

--- a/openfeature-provider/go/confidence/flag_logger_e2e_test.go
+++ b/openfeature-provider/go/confidence/flag_logger_e2e_test.go
@@ -3,6 +3,7 @@ package confidence
 import (
 	"context"
 	"log/slog"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -13,10 +14,9 @@ import (
 
 // End-to-end tests that verify WriteFlagLogs successfully sends to the real backend.
 
-const (
-	flagLogsClientSecret = "ti5Sipq5EluCYRG7I5cdbpWC3xq7JTWv"
-	flagLogsTargetingKey = "test-a"
-)
+var flagLogsClientSecret = os.Getenv("CONFIDENCE_CLIENT_SECRET")
+
+const flagLogsTargetingKey = "test-a"
 
 // TestFlagLogs_ShouldSuccessfullySendToRealBackend tests that we can successfully
 // send WriteFlagLogs to the real Confidence backend and get a successful response.

--- a/openfeature-provider/go/confidence/flag_logs_test.go
+++ b/openfeature-provider/go/confidence/flag_logs_test.go
@@ -23,10 +23,9 @@ import (
 //   - Assignment information is present and valid
 //   - Variant information matches the resolved value
 
-const (
-	unitTestClientSecret = "ti5Sipq5EluCYRG7I5cdbpWC3xq7JTWv"
-	unitTestTargetingKey = "test-a"
-)
+var unitTestClientSecret = os.Getenv("CONFIDENCE_CLIENT_SECRET")
+
+const unitTestTargetingKey = "test-a"
 
 // setupFlagLogsUnitTest creates a provider with a capturing logger for testing.
 // Returns the capturing logger, provider, and client.

--- a/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProviderFlagLogsIT.java
+++ b/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProviderFlagLogsIT.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  * run against the shaded JAR to verify shading is correct.
  */
 class OpenFeatureLocalResolveProviderFlagLogsIT {
-  private static final String FLAG_CLIENT_SECRET = "ti5Sipq5EluCYRG7I5cdbpWC3xq7JTWv";
+  private static final String FLAG_CLIENT_SECRET = System.getenv("CONFIDENCE_CLIENT_SECRET");
   private static final String TARGETING_KEY = "test-a";
 
   @AfterEach

--- a/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProviderFlagLogsTest.java
+++ b/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProviderFlagLogsTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
  * </ul>
  */
 class OpenFeatureLocalResolveProviderFlagLogsTest {
-  private static final String FLAG_CLIENT_SECRET = "ti5Sipq5EluCYRG7I5cdbpWC3xq7JTWv";
+  private static final String FLAG_CLIENT_SECRET = System.getenv("CONFIDENCE_CLIENT_SECRET");
   private static final String TARGETING_KEY = "test-a";
   private Client client;
   private CapturingWasmFlagLogger capturingLogger;

--- a/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProviderIT.java
+++ b/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProviderIT.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
  * shaded JAR to verify shading is correct.
  */
 class OpenFeatureLocalResolveProviderIT {
-  private static final String FLAG_CLIENT_SECRET = "ti5Sipq5EluCYRG7I5cdbpWC3xq7JTWv";
+  private static final String FLAG_CLIENT_SECRET = System.getenv("CONFIDENCE_CLIENT_SECRET");
   private static Client client;
 
   @BeforeAll
@@ -101,7 +101,7 @@ class OpenFeatureLocalResolveProviderIT {
 
   @Test
   void shouldResolveFlagWithStickyResolveAndRemoteMaterializationStore() {
-    final EvaluationContext stickyContext = new MutableContext("test-a").add("sticky", true);
+    final EvaluationContext stickyContext = new MutableContext("test-3").add("sticky", true);
 
     final FlagEvaluationDetails<Double> details =
         client.getDoubleDetails("web-sdk-e2e-flag.double", -1.0, stickyContext);

--- a/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/WasmResolveApiFlushCloseRaceTest.java
+++ b/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/WasmResolveApiFlushCloseRaceTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
  * operations.
  */
 class WasmResolveApiFlushCloseRaceTest {
-  private static final String FLAG_CLIENT_SECRET = "ti5Sipq5EluCYRG7I5cdbpWC3xq7JTWv";
+  private static final String FLAG_CLIENT_SECRET = System.getenv("CONFIDENCE_CLIENT_SECRET");
   private static final String TARGETING_KEY = "test-race";
 
   private static byte[] resolverState;

--- a/openfeature-provider/js/AGENTS.md
+++ b/openfeature-provider/js/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.e2e.test.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.e2e.test.ts
@@ -8,7 +8,7 @@ const moduleBytes = readFileSync(__dirname + '/../../../wasm/confidence_resolver
 const module = new WebAssembly.Module(moduleBytes);
 const resolver = new WasmResolver(module);
 const confidenceProvider = new ConfidenceServerProviderLocal(resolver, {
-  flagClientSecret: 'ti5Sipq5EluCYRG7I5cdbpWC3xq7JTWv',
+  flagClientSecret: process.env.CONFIDENCE_CLIENT_SECRET!,
   materializationStore: 'CONFIDENCE_REMOTE_STORE',
 });
 
@@ -83,7 +83,7 @@ describe('ConfidenceServerProvider E2E tests', () => {
   it('should resolve a flag with a sticky resolve', async () => {
     const client = OpenFeature.getClient();
     const result = await client.getNumberDetails('web-sdk-e2e-flag.double', -1, {
-      targetingKey: 'test-a',
+      targetingKey: 'test-3',
       sticky: true,
     });
 

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.flaglogs.e2e.test.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.flaglogs.e2e.test.ts
@@ -11,7 +11,7 @@ import { createCapturingLoggingBackend } from './test-helpers';
  */
 
 const moduleBytes = readFileSync(__dirname + '/../../../wasm/confidence_resolver.wasm');
-const FLAG_CLIENT_SECRET = 'ti5Sipq5EluCYRG7I5cdbpWC3xq7JTWv';
+const FLAG_CLIENT_SECRET = process.env.CONFIDENCE_CLIENT_SECRET!;
 const TARGETING_KEY = 'test-a';
 
 describe('WriteFlagLogs Backend E2E tests', () => {

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.flaglogs.test.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.flaglogs.test.ts
@@ -17,7 +17,7 @@ import { WriteFlagLogsRequest } from './proto/test-only';
  */
 
 const moduleBytes = readFileSync(__dirname + '/../../../wasm/confidence_resolver.wasm');
-const FLAG_CLIENT_SECRET = 'ti5Sipq5EluCYRG7I5cdbpWC3xq7JTWv';
+const FLAG_CLIENT_SECRET = process.env.CONFIDENCE_CLIENT_SECRET!;
 const TARGETING_KEY = 'test-a';
 
 describe('WriteFlagLogs tests', () => {

--- a/openfeature-provider/python/tests/conftest.py
+++ b/openfeature-provider/python/tests/conftest.py
@@ -1,5 +1,6 @@
 """Shared pytest fixtures for Confidence OpenFeature provider tests."""
 
+import os
 from pathlib import Path
 from typing import Optional, Protocol, Tuple
 
@@ -146,4 +147,4 @@ def mock_state_fetcher(
 @pytest.fixture
 def e2e_client_secret() -> str:
     """Client secret for E2E tests."""
-    return "Ip7lGcBeGA4Le9MI8md4i5LkUOnLnyFx"
+    return os.environ["CONFIDENCE_CLIENT_SECRET"]

--- a/openfeature-provider/python/tests/e2e_test.py
+++ b/openfeature-provider/python/tests/e2e_test.py
@@ -3,10 +3,12 @@
 from openfeature import api
 from openfeature.evaluation_context import EvaluationContext
 
+import os
+
 from confidence import ConfidenceProvider
 
 # E2E test configuration - matches Go e2e_test.go
-E2E_CLIENT_SECRET = "Ip7lGcBeGA4Le9MI8md4i5LkUOnLnyFx"
+E2E_CLIENT_SECRET = os.environ["CONFIDENCE_CLIENT_SECRET"]
 E2E_INCLUDED_TARGETING_KEY = "user-a"
 E2E_EXCLUDED_TARGETING_KEY = "user-x"
 

--- a/openfeature-provider/python/tests/flaglogs_e2e_test.py
+++ b/openfeature-provider/python/tests/flaglogs_e2e_test.py
@@ -5,10 +5,12 @@ import time
 from openfeature import api
 from openfeature.evaluation_context import EvaluationContext
 
+import os
+
 from confidence import ConfidenceProvider
 
 # E2E test configuration
-E2E_CLIENT_SECRET = "Ip7lGcBeGA4Le9MI8md4i5LkUOnLnyFx"
+E2E_CLIENT_SECRET = os.environ["CONFIDENCE_CLIENT_SECRET"]
 
 
 class TestFlagLogging:

--- a/openfeature-provider/rust/examples/bench.rs
+++ b/openfeature-provider/rust/examples/bench.rs
@@ -26,7 +26,7 @@ const DEFAULT_MOCK_ADDR: &str = "http://localhost:8081";
 const DEFAULT_DURATION_SECS: u64 = 30;
 const DEFAULT_WARMUP_SECS: u64 = 5;
 const DEFAULT_FLAG_KEY: &str = "web-sdk-e2e-flag";
-const DEFAULT_CLIENT_SECRET: &str = "ti5Sipq5EluCYRG7I5cdbpWC3xq7JTWv";
+const DEFAULT_CLIENT_SECRET: &str = "IlDJIFpDSs51URW04NW1JqjleJTm2Fzo";
 
 struct Args {
     mock_addr: String,

--- a/openfeature-provider/rust/tests/e2e.rs
+++ b/openfeature-provider/rust/tests/e2e.rs
@@ -7,8 +7,11 @@
 use open_feature::{EvaluationContext, EvaluationReason, OpenFeature, StructValue, Value};
 use spotify_confidence_openfeature_provider_local::{ConfidenceProvider, ProviderOptions};
 
-const CLIENT_SECRET: &str = "ti5Sipq5EluCYRG7I5cdbpWC3xq7JTWv";
+fn client_secret() -> String {
+    std::env::var("CONFIDENCE_CLIENT_SECRET").expect("CONFIDENCE_CLIENT_SECRET must be set")
+}
 const TARGETING_KEY: &str = "test-a"; // control variant
+const STICKY_TARGETING_KEY: &str = "test-3"; // sticky variant
 
 fn context() -> EvaluationContext {
     EvaluationContext::default()
@@ -18,14 +21,15 @@ fn context() -> EvaluationContext {
 
 fn sticky_context() -> EvaluationContext {
     EvaluationContext::default()
-        .with_targeting_key(TARGETING_KEY)
+        .with_targeting_key(STICKY_TARGETING_KEY)
         .with_custom_field("sticky", true)
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn e2e_tests() {
     // Initialize provider
-    let options = ProviderOptions::new(CLIENT_SECRET).with_confidence_materialization_store();
+    let secret = client_secret();
+    let options = ProviderOptions::new(&secret).with_confidence_materialization_store();
     let provider = ConfidenceProvider::new(options).expect("Failed to create provider");
 
     let mut ofe = OpenFeature::singleton_mut().await;


### PR DESCRIPTION
## Summary
- Read client secret from `CONFIDENCE_CLIENT_SECRET` env var via Docker `--mount=type=secret`
- Core resolver tests using state snapshots keep their embedded secrets unchanged
- Sticky tests use `test-3` targeting key (materialized in new workspace)
- Dockerfile e2e/test stages mount the secret — never persisted in layers

## After merging
Add repo secret `CONFIDENCE_CLIENT_SECRET` via GitHub Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)