### PR TITLE
fix(java): add gRPC keepalive and idle timeout to DefaultChannelFactory

### DIFF
--- a/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/DefaultChannelFactory.java
+++ b/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/DefaultChannelFactory.java
@@ -7,6 +7,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Default implementation of ChannelFactory that creates standard gRPC channels with security
@@ -28,7 +29,11 @@ public class DefaultChannelFactory implements ChannelFactory {
             .map(Boolean::parseBoolean)
             .orElse(false);
 
-    ManagedChannelBuilder<?> builder = ManagedChannelBuilder.forTarget(target);
+    ManagedChannelBuilder<?> builder =
+        ManagedChannelBuilder.forTarget(target)
+            .keepAliveTime(5, TimeUnit.MINUTES)
+            .keepAliveTimeout(20, TimeUnit.SECONDS)
+            .idleTimeout(30, TimeUnit.MINUTES);
     if (useGrpcPlaintext) {
       builder = builder.usePlaintext();
     }


### PR DESCRIPTION
## Summary

The SDK's gRPC channel had no keepalive or idle timeout configured. When envoy (or an intermediate LB) cycles long-lived HTTP/2 connections, the channel discovers the dead connection mid-write, causing "Failed to write flag logs" errors from `GrpcWasmFlagLogger`. These always appear in bursts because all multiplexed gRPC streams on the same connection fail simultaneously.

This aligns `DefaultChannelFactory` with Apollo's `GrpcChannelFactory` client defaults:

| Setting | Value |
|---------|-------|
| `keepAliveTime` | 5 min |
| `keepAliveTimeout` | 20s |
| `idleTimeout` | 30 min |

## Test plan

- [x] `GrpcWasmFlagLoggerTest` passes (6/6)
- [ ] Deploy and monitor for "Failed to write flag logs" connection reset errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)