### PR TITLE
docs(java): document default gRPC connection settings

### DIFF
--- a/openfeature-provider/java/README.md
+++ b/openfeature-provider/java/README.md
@@ -147,6 +147,16 @@ The following environment variables are deprecated and will be removed in a futu
 
 ### Custom Channel Factory (Advanced)
 
+The built-in `DefaultChannelFactory` configures sensible gRPC connection defaults:
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| `keepAliveTime` | 5 min | Sends HTTP/2 pings to detect dead connections |
+| `keepAliveTimeout` | 20s | Time to wait for a keepalive ping response |
+| `idleTimeout` | 30 min | Closes channels with no active RPCs |
+
+These defaults prevent connection-reset errors when intermediate load balancers (e.g., Envoy) cycle long-lived HTTP/2 connections. If you provide a custom `ChannelFactory`, you may want to replicate these settings.
+
 For testing or advanced production scenarios, you can provide a custom `ChannelFactory` to control how gRPC channels are created:
 
 ```java


### PR DESCRIPTION
## Summary

- Documents the default gRPC keepalive and idle timeout settings added in #418
- Helps users who provide a custom `ChannelFactory` know what defaults they're replacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)