### PR TITLE
feat(go): skip apply via context key

### DIFF
--- a/openfeature-provider/go/confidence/provider.go
+++ b/openfeature-provider/go/confidence/provider.go
@@ -19,9 +19,14 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+type contextKey string
+
 const (
 	defaultStatePollIntervalSeconds = 10
 	defaultLogPollIntervalSeconds   = 15
+
+	// SkipApplyContextKey disables apply-on-resolve when set to true in context.Context.
+	SkipApplyContextKey contextKey = "_confidence_skip_apply"
 )
 
 type LocalResolverSupplier func(context.Context, lr.LogSink) lr.LocalResolver
@@ -248,7 +253,7 @@ func evaluate[T any](
 		})
 	}
 
-	response, err := p.resolveFlags(evalCtx, []string{requestFlagName}, true)
+	response, err := p.resolveFlags(evalCtx, []string{requestFlagName}, !skipApplyFromContext(ctx))
 	if err != nil {
 		var matErr *MaterializationNotSupportedError
 		if errors.As(err, &matErr) {
@@ -399,7 +404,7 @@ func (p *LocalResolverProvider) Resolve(
 		requestFlags[i] = "flags/" + name
 	}
 
-	return p.resolveFlags(evalCtx, requestFlags, apply)
+	return p.resolveFlags(evalCtx, requestFlags, apply && !skipApplyFromContext(ctx))
 }
 
 // ApplyFlags records exposure events for flags previously resolved with
@@ -651,6 +656,14 @@ func processTargetingKey(evalCtx openfeature.FlattenedContext) openfeature.Flatt
 	}
 
 	return newEvalContext
+}
+
+func skipApplyFromContext(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	skipApply, _ := ctx.Value(SkipApplyContextKey).(bool)
+	return skipApply
 }
 
 // flattenedContextToProto converts OpenFeature FlattenedContext to protobuf Struct

--- a/openfeature-provider/go/confidence/provider_test.go
+++ b/openfeature-provider/go/confidence/provider_test.go
@@ -46,6 +46,126 @@ func TestLocalResolverProvider_Hooks(t *testing.T) {
 	}
 }
 
+type typedObjectFlag struct {
+	Message string `json:"message"`
+	Limit   int    `json:"limit"`
+}
+
+func TestLocalResolverProvider_ObjectEvaluationWithSkipApplyContextReturnsTypedStruct(t *testing.T) {
+	provider := NewLocalResolverProvider(nil, nil, nil, "test-secret", nil)
+	var resolvedApply bool
+	var resolvedFlags []string
+	var resolvedContext *structpb.Struct
+	ctx := context.WithValue(context.Background(), SkipApplyContextKey, true)
+
+	provider.resolver = &mockResolverAPIForInit{
+		resolveProcess: func(request *wasm.ResolveProcessRequest) (*wasm.ResolveProcessResponse, error) {
+			resolveRequest := request.GetWithoutMaterializations()
+			if resolveRequest == nil {
+				t.Fatalf("expected resolve request without materializations, got %#v", request)
+			}
+			resolvedApply = resolveRequest.GetApply()
+			resolvedFlags = resolveRequest.GetFlags()
+			resolvedContext = resolveRequest.GetEvaluationContext()
+
+			value, err := structpb.NewStruct(map[string]any{
+				"message": "resolved",
+				"limit":   7,
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			return &wasm.ResolveProcessResponse{
+				Result: &wasm.ResolveProcessResponse_Resolved_{
+					Resolved: &wasm.ResolveProcessResponse_Resolved{
+						Response: &resolver.ResolveFlagsResponse{
+							ResolvedFlags: []*resolver.ResolvedFlag{
+								{
+									Flag:    "flags/typed-object",
+									Variant: "flags/typed-object/variants/treatment",
+									Value:   value,
+									Reason:  resolver.ResolveReason_RESOLVE_REASON_MATCH,
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	result := provider.ObjectEvaluation(
+		ctx,
+		"typed-object",
+		typedObjectFlag{},
+		openfeature.FlattenedContext{
+			"targeting_key": "user-123",
+		},
+	)
+
+	if err := result.Error(); err != nil {
+		t.Fatalf("expected no resolution error, got %v", err)
+	}
+	if resolvedApply {
+		t.Fatal("expected apply=false in resolve request")
+	}
+	if !slices.Equal(resolvedFlags, []string{"flags/typed-object"}) {
+		t.Fatalf("unexpected resolved flags: got %v", resolvedFlags)
+	}
+	if _, ok := resolvedContext.GetFields()[string(SkipApplyContextKey)]; ok {
+		t.Fatalf("expected %s not to be sent in the resolver context", SkipApplyContextKey)
+	}
+	if _, ok := result.Value.(*structpb.Struct); ok {
+		t.Fatalf("expected typed struct value, got protobuf struct")
+	}
+
+	got, ok := result.Value.(typedObjectFlag)
+	if !ok {
+		t.Fatalf("expected typedObjectFlag, got %T", result.Value)
+	}
+	if got != (typedObjectFlag{Message: "resolved", Limit: 7}) {
+		t.Fatalf("unexpected result: got %+v", got)
+	}
+}
+
+func TestLocalResolverProvider_ResolveWithSkipApplyContext(t *testing.T) {
+	provider := NewLocalResolverProvider(nil, nil, nil, "test-secret", nil)
+	var resolvedApply bool
+
+	provider.resolver = &mockResolverAPIForInit{
+		resolveProcess: func(request *wasm.ResolveProcessRequest) (*wasm.ResolveProcessResponse, error) {
+			resolveRequest := request.GetWithoutMaterializations()
+			if resolveRequest == nil {
+				t.Fatalf("expected resolve request without materializations, got %#v", request)
+			}
+			resolvedApply = resolveRequest.GetApply()
+
+			return &wasm.ResolveProcessResponse{
+				Result: &wasm.ResolveProcessResponse_Resolved_{
+					Resolved: &wasm.ResolveProcessResponse_Resolved{
+						Response: &resolver.ResolveFlagsResponse{},
+					},
+				},
+			}, nil
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), SkipApplyContextKey, true)
+	_, err := provider.Resolve(
+		ctx,
+		openfeature.FlattenedContext{"targeting_key": "user-123"},
+		[]string{"typed-object"},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("expected no resolve error, got %v", err)
+	}
+	if resolvedApply {
+		t.Fatal("expected apply=false in resolve request")
+	}
+}
+
 func TestParseFlagPath(t *testing.T) {
 	testCases := []struct {
 		name         string


### PR DESCRIPTION
## Summary
- add `confidence.SkipApplyContextKey` for Go `context.Context` so callers can force resolve requests to use `apply=false`
- apply the context-key behavior to both OpenFeature evaluation methods and direct `provider.Resolve(ctx, ...)`
- add regression coverage for typed object evaluation and direct `Resolve` with the skip-apply context key

## How it works
Set `confidence.SkipApplyContextKey` to `true` on the Go `context.Context` passed into the provider. The provider reads that key before building the resolver request and flips `apply` to `false`. The key is not part of the OpenFeature evaluation context, so it is not sent to the resolver as a targeting attribute.

```go
ctx := context.WithValue(
    context.Background(),
    confidence.SkipApplyContextKey,
    true,
)

resp, err := provider.Resolve(
    ctx,
    openfeature.FlattenedContext{
        "targeting_key": "user-123",
    },
    []string{"my-flag"},
    true, // normally apply, but the context key forces apply=false
)
```

The same context key also works with normal OpenFeature evaluation calls:

```go
ctx := context.WithValue(context.Background(), confidence.SkipApplyContextKey, true)

result := provider.BooleanEvaluation(
    ctx,
    "my-flag",
    false,
    openfeature.FlattenedContext{"targeting_key": "user-123"},
)
```

When skip-apply is enabled, the resolve response can include a resolve token for deferred apply. The caller can later record exposure with `ApplyFlags`.

## Testing
- `go test ./confidence -run TestLocalResolverProvider -count=1`
- `go test ./confidence -run 'TestLocalResolverProvider_(ObjectEvaluationWithSkipApplyContextReturnsTypedStruct|ResolveWithSkipApplyContext)|TestProcessTargetingKey|TestFlattenedContextToProto' -count=1`
- `git diff --check`

Note: full `go test ./confidence` still hits existing integration-style tests that require configured client secret/backend state.