### PR TITLE
feat: support skipping apply using context key

### DIFF
--- a/openfeature-provider/go/README.md
+++ b/openfeature-provider/go/README.md
@@ -490,6 +490,22 @@ The provider logs at different levels: `Debug` (flag resolution details), `Info`
 
 The shutdown respects the context timeout you provide.
 
+## Advanced: Controlling Exposure Events
+
+By default, every flag evaluation triggers an exposure event (apply). If you need to resolve a flag without recording an exposure, you can pass `_confidence_skip_apply` in the evaluation context:
+
+```go
+evalCtx := openfeature.NewEvaluationContext("user-123", map[string]interface{}{
+    "_confidence_skip_apply": true,
+})
+
+value, err := client.BooleanValue(ctx, "my-flag.enabled", false, evalCtx)
+```
+
+The key is automatically stripped from the context before it reaches the resolver.
+
+This is an advanced feature intended for specific use cases such as prefetching or background evaluation. If you're considering using it, reach out to the Confidence team to discuss the best approach for your setup.
+
 ## License
 
 See the root `LICENSE` file.

--- a/openfeature-provider/go/confidence/provider.go
+++ b/openfeature-provider/go/confidence/provider.go
@@ -248,7 +248,15 @@ func evaluate[T any](
 		})
 	}
 
-	response, err := p.resolveFlags(evalCtx, []string{requestFlagName}, true)
+	apply := true
+	if skip, ok := evalCtx["_confidence_skip_apply"]; ok {
+		if b, ok := skip.(bool); ok && b {
+			apply = false
+		}
+		delete(evalCtx, "_confidence_skip_apply")
+	}
+
+	response, err := p.resolveFlags(evalCtx, []string{requestFlagName}, apply)
 	if err != nil {
 		var matErr *MaterializationNotSupportedError
 		if errors.As(err, &matErr) {

--- a/openfeature-provider/go/confidence/provider_resolve_test.go
+++ b/openfeature-provider/go/confidence/provider_resolve_test.go
@@ -153,6 +153,45 @@ func TestLocalResolverProvider_ReturnsCorrectValue(t *testing.T) {
 	})
 }
 
+func TestLocalResolverProvider_SkipApplyContextKey(t *testing.T) {
+	ctx := context.Background()
+
+	testState := tu.LoadTestResolverState(t)
+	testAcctID := tu.LoadTestAccountID(t)
+
+	stateProvider := &tu.StateProviderMock{
+		State:     testState,
+		AccountID: testAcctID,
+	}
+	mockFlagLogger := &tu.MockFlagLogger{}
+	unsupportedMatStore := newUnsupportedMaterializationStore()
+
+	resolverSupplier := wrapResolverSupplierWithMaterializations(func(ctx context.Context, logSink lr.LogSink) lr.LocalResolver {
+		return lr.NewLocalResolverWithPoolSize(ctx, logSink, 2)
+	}, unsupportedMatStore)
+	openfeature.SetProviderAndWait(NewLocalResolverProvider(resolverSupplier, stateProvider, mockFlagLogger, "mkjJruAATQWjeY7foFIWfVAcBWnci2YF", slog.New(slog.NewTextHandler(os.Stderr, nil))))
+	client := openfeature.NewClient("test-client")
+
+	evalCtx := openfeature.NewTargetlessEvaluationContext(map[string]interface{}{
+		"visitor_id":              "tutorial_visitor",
+		"_confidence_skip_apply": true,
+	})
+
+	t.Run("resolves correctly with _confidence_skip_apply in context", func(t *testing.T) {
+		result, err := client.StringValueDetails(ctx, "tutorial-feature.message", "default-message", evalCtx)
+		if err != nil {
+			t.Errorf("Error during StringValueDetails: %v", err)
+		}
+		expectedMessage := "We are very excited to welcome you to Confidence! This is a message from the tutorial flag."
+		if result.Value != expectedMessage {
+			t.Errorf("Expected value '%s', got '%s'", expectedMessage, result.Value)
+		}
+		if result.Reason != openfeature.TargetingMatchReason {
+			t.Errorf("Expected TargetingMatchReason, got %v", result.Reason)
+		}
+	})
+}
+
 func TestLocalResolverProvider_PathNotFound(t *testing.T) {
 	ctx := context.Background()
 	runtime := lr.DefaultResolverFactory(lr.NoOpLogSink)

--- a/openfeature-provider/go/confidence/provider_resolve_test.go
+++ b/openfeature-provider/go/confidence/provider_resolve_test.go
@@ -173,7 +173,7 @@ func TestLocalResolverProvider_SkipApplyContextKey(t *testing.T) {
 	client := openfeature.NewClient("test-client")
 
 	evalCtx := openfeature.NewTargetlessEvaluationContext(map[string]interface{}{
-		"visitor_id":              "tutorial_visitor",
+		"visitor_id":             "tutorial_visitor",
 		"_confidence_skip_apply": true,
 	})
 

--- a/openfeature-provider/java/README.md
+++ b/openfeature-provider/java/README.md
@@ -368,6 +368,21 @@ const confidence = Confidence.create({
 });
 ```
 
+## Advanced: Controlling Exposure Events
+
+By default, every flag evaluation triggers an exposure event (apply). If you need to resolve a flag without recording an exposure, you can pass `_confidence_skip_apply` in the evaluation context:
+
+```java
+MutableContext context = new MutableContext("user-123");
+context.add("_confidence_skip_apply", true);
+
+boolean value = client.getBooleanValue("my-flag.enabled", false, context);
+```
+
+The key is automatically stripped from the context before it reaches the resolver.
+
+This is an advanced feature intended for specific use cases such as prefetching or background evaluation. If you're considering using it, reach out to the Confidence team to discuss the best approach for your setup.
+
 ## Requirements
 
 - Java 17+

--- a/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProvider.java
+++ b/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProvider.java
@@ -388,6 +388,7 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
       throw new RuntimeException(e);
     }
 
+    final boolean skipApply = OpenFeatureUtils.isSkipApply(ctx);
     final Struct evaluationContext = OpenFeatureUtils.convertToProto(ctx);
     ResolveFlagsResponse resolveFlagResponse;
     try {
@@ -396,7 +397,7 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
       final var req =
           ResolveFlagsRequest.newBuilder()
               .addFlags(requestFlagName)
-              .setApply(true)
+              .setApply(!skipApply)
               .setClientSecret(clientSecret)
               .setEvaluationContext(
                   Struct.newBuilder().putAllFields(evaluationContext.getFieldsMap()).build())

--- a/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/OpenFeatureUtils.java
+++ b/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/OpenFeatureUtils.java
@@ -13,7 +13,13 @@ import org.slf4j.Logger;
 class OpenFeatureUtils {
 
   static final String TARGETING_KEY = "targeting_key";
+  static final String SKIP_APPLY_KEY = "_confidence_skip_apply";
   private static final Logger log = org.slf4j.LoggerFactory.getLogger(OpenFeatureUtils.class);
+
+  static boolean isSkipApply(EvaluationContext evaluationContext) {
+    final Value value = evaluationContext.getValue(SKIP_APPLY_KEY);
+    return value != null && value.isBoolean() && value.asBoolean();
+  }
 
   /*
   OpenFeature Evaluation Context -> Proto
@@ -24,7 +30,9 @@ class OpenFeatureUtils {
         .asMap()
         .forEach(
             (mapKey, mapValue) -> {
-              protoEvaluationContext.putFields(mapKey, OpenFeatureTypeMapper.from(mapValue));
+              if (!SKIP_APPLY_KEY.equals(mapKey)) {
+                protoEvaluationContext.putFields(mapKey, OpenFeatureTypeMapper.from(mapValue));
+              }
             });
     // add targeting key as a regular value to proto struct
     if (evaluationContext.getTargetingKey() != null

--- a/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/OpenFeatureUtilsTest.java
+++ b/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/OpenFeatureUtilsTest.java
@@ -1,0 +1,42 @@
+package com.spotify.confidence.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.openfeature.sdk.MutableContext;
+import org.junit.jupiter.api.Test;
+
+class OpenFeatureUtilsTest {
+
+  @Test
+  void isSkipApply_returnsTrueWhenSet() {
+    final var ctx = new MutableContext("user-1");
+    ctx.add("_confidence_skip_apply", true);
+    assertThat(OpenFeatureUtils.isSkipApply(ctx)).isTrue();
+  }
+
+  @Test
+  void isSkipApply_returnsFalseWhenNotSet() {
+    final var ctx = new MutableContext("user-1");
+    assertThat(OpenFeatureUtils.isSkipApply(ctx)).isFalse();
+  }
+
+  @Test
+  void isSkipApply_returnsFalseWhenSetToFalse() {
+    final var ctx = new MutableContext("user-1");
+    ctx.add("_confidence_skip_apply", false);
+    assertThat(OpenFeatureUtils.isSkipApply(ctx)).isFalse();
+  }
+
+  @Test
+  void convertToProto_stripsSkipApplyKey() {
+    final var ctx = new MutableContext("user-1");
+    ctx.add("_confidence_skip_apply", true);
+    ctx.add("country", "SE");
+
+    final var proto = OpenFeatureUtils.convertToProto(ctx);
+
+    assertThat(proto.getFieldsMap()).doesNotContainKey("_confidence_skip_apply");
+    assertThat(proto.getFieldsMap()).containsKey("country");
+    assertThat(proto.getFieldsMap()).containsKey("targeting_key");
+  }
+}

--- a/openfeature-provider/js/README.md
+++ b/openfeature-provider/js/README.md
@@ -339,6 +339,23 @@ yarn add debug
 
 ---
 
+## Advanced: Controlling Exposure Events
+
+By default, every flag evaluation triggers an exposure event (apply). If you need to resolve a flag without recording an exposure, you can pass `_confidence_skip_apply: true` in the evaluation context:
+
+```typescript
+const value = await client.getBooleanValue('my-flag.enabled', false, {
+  targetingKey: 'user-123',
+  _confidence_skip_apply: true,
+});
+```
+
+The key is automatically stripped from the context before it reaches the resolver.
+
+This is an advanced feature intended for specific use cases such as prefetching or background evaluation. If you're considering using it, reach out to the Confidence team to discuss the best approach for your setup.
+
+---
+
 ## License
 
 See the root `LICENSE`.

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.test.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.test.ts
@@ -303,6 +303,43 @@ describe('remote materialization for sticky assignments', () => {
     expect(net.resolver.readMaterializations.calls).toBe(0);
   });
 
+  it('sets apply=false when _confidence_skip_apply is true in context', async () => {
+    await advanceTimersUntil(expect(provider.initialize()).resolves.toBeUndefined());
+
+    mockedWasmResolver.resolveProcess.mockReturnValue({
+      resolved: {
+        response: {
+          resolvedFlags: [
+            {
+              flag: 'flags/test-flag',
+              variant: 'variant-a',
+              value: { enabled: true },
+              reason: RESOLVE_REASON_MATCH,
+              shouldApply: true,
+            },
+          ],
+          resolveToken: new Uint8Array(),
+          resolveId: 'resolve-123',
+        },
+        materializationsToWrite: [],
+      },
+    });
+
+    await provider.resolveBooleanEvaluation('test-flag.enabled', false, {
+      targetingKey: 'user-123',
+      _confidence_skip_apply: true,
+    });
+
+    expect(mockedWasmResolver.resolveProcess).toHaveBeenCalledWith({
+      deferredMaterializations: expect.objectContaining({
+        apply: false,
+        evaluationContext: expect.not.objectContaining({
+          _confidence_skip_apply: true,
+        }),
+      }),
+    });
+  });
+
   it('reads materializations from remote when WASM reports missing materializations', async () => {
     await advanceTimersUntil(expect(provider.initialize()).resolves.toBeUndefined());
 

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
@@ -200,8 +200,9 @@ export class ConfidenceServerProviderLocal implements Provider {
     const startMs = performance.now();
     try {
       const [flagName] = flagKey.split('.', 1);
-      const skipApply = context._confidence_skip_apply === true;
-      const resolution = await this.resolve(context, [flagName], !skipApply);
+      const { _confidence_skip_apply, ...cleanContext } = context;
+      const skipApply = _confidence_skip_apply === true;
+      const resolution = await this.resolve(cleanContext as EvaluationContext, [flagName], !skipApply);
       const result = FlagBundle.resolve(resolution, flagKey, defaultValue, logger);
 
       const latencyUs = Math.round((performance.now() - startMs) * 1000);
@@ -356,11 +357,7 @@ export class ConfidenceServerProviderLocal implements Provider {
     throw new Error('Write materialization not supported');
   }
 
-  private static convertEvaluationContext({
-    targetingKey: targeting_key,
-    _confidence_skip_apply,
-    ...rest
-  }: EvaluationContext): {
+  private static convertEvaluationContext({ targetingKey: targeting_key, ...rest }: EvaluationContext): {
     [key: string]: any;
   } {
     return {

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
@@ -200,7 +200,8 @@ export class ConfidenceServerProviderLocal implements Provider {
     const startMs = performance.now();
     try {
       const [flagName] = flagKey.split('.', 1);
-      const resolution = await this.resolve(context, [flagName], true);
+      const skipApply = context._confidence_skip_apply === true;
+      const resolution = await this.resolve(context, [flagName], !skipApply);
       const result = FlagBundle.resolve(resolution, flagKey, defaultValue, logger);
 
       const latencyUs = Math.round((performance.now() - startMs) * 1000);
@@ -355,7 +356,11 @@ export class ConfidenceServerProviderLocal implements Provider {
     throw new Error('Write materialization not supported');
   }
 
-  private static convertEvaluationContext({ targetingKey: targeting_key, ...rest }: EvaluationContext): {
+  private static convertEvaluationContext({
+    targetingKey: targeting_key,
+    _confidence_skip_apply,
+    ...rest
+  }: EvaluationContext): {
     [key: string]: any;
   } {
     return {

--- a/openfeature-provider/python/README.md
+++ b/openfeature-provider/python/README.md
@@ -233,6 +233,23 @@ import logging
 logging.getLogger("confidence").setLevel(logging.DEBUG)
 ```
 
+## Advanced: Controlling Exposure Events
+
+By default, every flag evaluation triggers an exposure event (apply). If you need to resolve a flag without recording an exposure, you can pass `_confidence_skip_apply` in the evaluation context:
+
+```python
+context = EvaluationContext(
+    targeting_key="user-123",
+    attributes={"_confidence_skip_apply": True},
+)
+
+value = client.get_boolean_value("my-flag.enabled", False, context)
+```
+
+The key is automatically stripped from the context before it reaches the resolver.
+
+This is an advanced feature intended for specific use cases such as prefetching or background evaluation. If you're considering using it, reach out to the Confidence team to discuss the best approach for your setup.
+
 ## License
 
 Apache 2.0

--- a/openfeature-provider/python/src/confidence/provider.py
+++ b/openfeature-provider/python/src/confidence/provider.py
@@ -456,9 +456,7 @@ class ConfidenceProvider(AbstractProvider):
             skip_apply = False
             if evaluation_context and evaluation_context.attributes:
                 skip_apply = (
-                    evaluation_context.attributes.pop(
-                        "_confidence_skip_apply", False
-                    )
+                    evaluation_context.attributes.pop("_confidence_skip_apply", False)
                     is True
                 )
 

--- a/openfeature-provider/python/src/confidence/provider.py
+++ b/openfeature-provider/python/src/confidence/provider.py
@@ -452,12 +452,22 @@ class ConfidenceProvider(AbstractProvider):
 
         try:
             flag_name, path = self._parse_flag_path(flag_key)
+
+            skip_apply = False
+            if evaluation_context and evaluation_context.attributes:
+                skip_apply = (
+                    evaluation_context.attributes.pop(
+                        "_confidence_skip_apply", False
+                    )
+                    is True
+                )
+
             proto_context = self._context_to_proto(evaluation_context)
 
             resolve_req = api_pb2.ResolveFlagsRequest()
             resolve_req.flags.append(f"flags/{flag_name}")
             resolve_req.client_secret = self._client_secret
-            resolve_req.apply = True
+            resolve_req.apply = not skip_apply
             if proto_context is not None:
                 resolve_req.evaluation_context.CopyFrom(proto_context)
             resolve_req.sdk.id = types_pb2.SdkId.SDK_ID_PYTHON_PROVIDER

--- a/openfeature-provider/python/tests/test_provider.py
+++ b/openfeature-provider/python/tests/test_provider.py
@@ -839,3 +839,85 @@ class TestPrometheusMetrics:
             assert "confidence_resolve_latency" in metrics
         finally:
             provider.shutdown()
+
+
+class TestSkipApply:
+    """Tests for _confidence_skip_apply context key."""
+
+    def test_resolve_with_skip_apply_still_resolves(
+        self,
+        wasm_bytes: bytes,
+        test_resolver_state: bytes,
+        test_account_id: str,
+        test_client_secret: str,
+    ) -> None:
+        """Test that _confidence_skip_apply does not prevent resolution."""
+        mock_fetcher = MockStateFetcher(test_resolver_state, test_account_id)
+        mock_logger = MockFlagLogger()
+
+        provider = ConfidenceProvider(
+            client_secret=test_client_secret,
+            state_fetcher=mock_fetcher,
+            flag_logger=mock_logger,
+            wasm_bytes=wasm_bytes,
+        )
+
+        provider.initialize(EvaluationContext())
+
+        try:
+            ctx = EvaluationContext(
+                targeting_key="test-user",
+                attributes={
+                    "visitor_id": "tutorial_visitor",
+                    "_confidence_skip_apply": True,
+                },
+            )
+            result = provider.resolve_string_details(
+                flag_key="tutorial-feature.message",
+                default_value="default-message",
+                evaluation_context=ctx,
+            )
+
+            assert result.reason == Reason.TARGETING_MATCH
+            assert result.value != "default-message"
+        finally:
+            provider.shutdown()
+
+    def test_skip_apply_key_is_stripped_from_context(
+        self,
+        wasm_bytes: bytes,
+        test_resolver_state: bytes,
+        test_account_id: str,
+        test_client_secret: str,
+    ) -> None:
+        """Test that _confidence_skip_apply is removed from attributes after resolve."""
+        mock_fetcher = MockStateFetcher(test_resolver_state, test_account_id)
+        mock_logger = MockFlagLogger()
+
+        provider = ConfidenceProvider(
+            client_secret=test_client_secret,
+            state_fetcher=mock_fetcher,
+            flag_logger=mock_logger,
+            wasm_bytes=wasm_bytes,
+        )
+
+        provider.initialize(EvaluationContext())
+
+        try:
+            attrs = {
+                "visitor_id": "tutorial_visitor",
+                "_confidence_skip_apply": True,
+            }
+            ctx = EvaluationContext(
+                targeting_key="test-user",
+                attributes=attrs,
+            )
+            provider.resolve_string_details(
+                flag_key="tutorial-feature.message",
+                default_value="default-message",
+                evaluation_context=ctx,
+            )
+
+            assert "_confidence_skip_apply" not in attrs
+        finally:
+            provider.shutdown()

--- a/openfeature-provider/rust/README.md
+++ b/openfeature-provider/rust/README.md
@@ -325,6 +325,24 @@ Consider implementing a materialization store if:
 If you don't use sticky assignments or materialized segments, the default behavior is sufficient.
 
 
+## Advanced: Controlling Exposure Events
+
+By default, every flag evaluation triggers an exposure event (apply). If you need to resolve a flag without recording an exposure, you can pass `_confidence_skip_apply` in the evaluation context:
+
+```rust
+let context = EvaluationContext::default()
+    .with_targeting_key("user-123")
+    .with_custom_field("_confidence_skip_apply", true);
+
+let value = client
+    .get_bool_value("my-flag.enabled", Some(&context), None)
+    .await;
+```
+
+The key is automatically stripped from the context before it reaches the resolver.
+
+This is an advanced feature intended for specific use cases such as prefetching or background evaluation. If you're considering using it, reach out to the Confidence team to discuss the best approach for your setup.
+
 ## License
 
 See the root `LICENSE` file.

--- a/openfeature-provider/rust/src/provider.rs
+++ b/openfeature-provider/rust/src/provider.rs
@@ -312,14 +312,25 @@ impl ConfidenceProvider {
         // Parse flag path
         let (flag_name, path) = parse_flag_path(flag_key);
 
+        // Check for skip apply before converting context
+        let mut context = context.clone();
+        let skip_apply = context
+            .custom_fields
+            .remove("_confidence_skip_apply")
+            .and_then(|v| match v {
+                EvaluationContextFieldValue::Bool(b) => Some(b),
+                _ => None,
+            })
+            .unwrap_or(false);
+
         // Convert evaluation context to protobuf
-        let proto_context = convert_evaluation_context(context);
+        let proto_context = convert_evaluation_context(&context);
 
         // Create resolve request
         let request = ResolveFlagsRequest {
             flags: vec![format!("flags/{}", flag_name)],
             evaluation_context: Some(proto_context.clone()),
-            apply: true,
+            apply: !skip_apply,
             client_secret: self.client_secret.clone(),
             sdk: Some(provider_sdk()),
         };
@@ -1576,5 +1587,50 @@ mod tests {
             .map(|r| r.value)
             .unwrap_or_else(|_| "my-default".to_string()); // Caller's default
         assert_eq!(string_value, "my-default", "Should use caller's default");
+    }
+
+    #[test]
+    fn test_skip_apply_key_stripped_from_context() {
+        let ctx = EvaluationContext::default()
+            .with_targeting_key("user-123")
+            .with_custom_field("country", "SE")
+            .with_custom_field("_confidence_skip_apply", true);
+
+        let mut ctx_clone = ctx.clone();
+        let skip_apply = ctx_clone
+            .custom_fields
+            .remove("_confidence_skip_apply")
+            .and_then(|v| match v {
+                EvaluationContextFieldValue::Bool(b) => Some(b),
+                _ => None,
+            })
+            .unwrap_or(false);
+
+        assert!(skip_apply);
+
+        let proto = convert_evaluation_context(&ctx_clone);
+        assert!(
+            !proto.fields.contains_key("_confidence_skip_apply"),
+            "Expected _confidence_skip_apply to be stripped from context"
+        );
+        assert!(proto.fields.contains_key("targeting_key"));
+        assert!(proto.fields.contains_key("country"));
+    }
+
+    #[test]
+    fn test_skip_apply_defaults_to_false() {
+        let ctx = EvaluationContext::default().with_targeting_key("user-123");
+
+        let mut ctx_clone = ctx.clone();
+        let skip_apply = ctx_clone
+            .custom_fields
+            .remove("_confidence_skip_apply")
+            .and_then(|v| match v {
+                EvaluationContextFieldValue::Bool(b) => Some(b),
+                _ => None,
+            })
+            .unwrap_or(false);
+
+        assert!(!skip_apply);
     }
 }


### PR DESCRIPTION
## Summary

- Adds support for a reserved evaluation context key `_confidence_skip_apply` across JS, Java, Go, Python, and Rust OpenFeature providers
- When set to `true`, the provider resolves the flag with `apply=false`, suppressing the exposure event
- The key is stripped from the context before it reaches the resolver — it never leaks into the targeting context

## Test plan

- [x] JS: vitest passes — verifies `resolveProcess` called with `apply: false` and key stripped from context
- [x] Java: `OpenFeatureUtilsTest` — `isSkipApply` returns correct values, `convertToProto` strips the key
- [x] Go: `TestLocalResolverProvider_SkipApplyContextKey` — resolves correctly with key in context
- [x] Python: `TestSkipApply` — resolves with skip apply, key stripped from attributes
- [x] Rust: unit tests for key stripping and default behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Replaces https://github.com/spotify/confidence-resolver/pull/420