### PR TITLE
chore: add sync-wasm-go-with-commit make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ sync-wasm-go:
 	@echo "  git add $(GO_WASM)/confidence_resolver.wasm"
 	@echo "  git commit -m 'chore: sync WASM module for Go provider'"
 
+.PHONY: sync-wasm-go-with-commit
+sync-wasm-go-with-commit: sync-wasm-go
+	git add $(GO_WASM)/confidence_resolver.wasm
+	git commit -m 'chore: sync WASM module for Go provider'
+
 # Build Cloudflare deployer image using main Dockerfile
 .PHONY: build-deployer
 build-deployer:


### PR DESCRIPTION
## Summary
- Adds `sync-wasm-go-with-commit` Make target that reuses `sync-wasm-go` and auto-commits the synced WASM binary.

## Test plan
- [ ] Run `make sync-wasm-go-with-commit` and verify it builds, syncs, and commits in one step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)