### PR TITLE
fix(java): drop pending poll on local provider shutdown

### DIFF
--- a/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProvider.java
+++ b/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProvider.java
@@ -57,8 +57,8 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
   private final MaterializationStore materializationStore;
   private static final Duration ASSIGN_LOG_FLUSH_INTERVAL = Duration.ofMillis(100);
   private static final Duration DEFAULT_POLL_INTERVAL = Duration.ofSeconds(15);
-  private final ScheduledExecutorService flagsFetcherExecutor =
-      Executors.newScheduledThreadPool(1, new ThreadFactoryBuilder().setDaemon(true).build());
+  private static final Duration SHUTDOWN_GRACE = Duration.ofSeconds(5);
+  private final ScheduledExecutorService flagsFetcherExecutor = newFlagsFetcherExecutor();
   private final ScheduledExecutorService assignLogExecutor =
       Executors.newScheduledThreadPool(1, new ThreadFactoryBuilder().setDaemon(true).build());
   private final AccountStateProvider stateProvider;
@@ -66,8 +66,18 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
       new AtomicReference<>(ProviderState.NOT_READY);
   private volatile boolean initialized = false;
   private volatile byte[] lastStateBytes = null;
+  @VisibleForTesting boolean forcedFetcherShutdown = false;
   private static final Sdk SDK =
       Sdk.newBuilder().setId(SdkId.SDK_ID_JAVA_LOCAL_PROVIDER).setVersion(Version.VERSION).build();
+
+  private static ScheduledExecutorService newFlagsFetcherExecutor() {
+    final ScheduledThreadPoolExecutor executor =
+        new ScheduledThreadPoolExecutor(1, new ThreadFactoryBuilder().setDaemon(true).build());
+    // The poll task reschedules itself, so there is always one pending. Drop it on shutdown instead
+    // of letting awaitTermination wait for a poll that won't fire for another poll interval.
+    executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+    return executor;
+  }
 
   private static long getPollIntervalSeconds() {
     return Optional.ofNullable(System.getenv("CONFIDENCE_RESOLVER_POLL_INTERVAL_SECONDS"))
@@ -341,13 +351,17 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
     flagsFetcherExecutor.shutdown();
     assignLogExecutor.shutdown();
 
+    final long graceSeconds = SHUTDOWN_GRACE.toSeconds();
     try {
-      if (!flagsFetcherExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
-        log.warn("Flags fetcher executor did not terminate gracefully");
+      if (!flagsFetcherExecutor.awaitTermination(graceSeconds, TimeUnit.SECONDS)) {
+        log.warn(
+            "Flags fetcher executor did not terminate within {}s, forcing shutdown", graceSeconds);
+        forcedFetcherShutdown = true;
         flagsFetcherExecutor.shutdownNow();
       }
-      if (!assignLogExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
-        log.warn("Assign log executor did not terminate gracefully");
+      if (!assignLogExecutor.awaitTermination(graceSeconds, TimeUnit.SECONDS)) {
+        log.warn(
+            "Assign log executor did not terminate within {}s, forcing shutdown", graceSeconds);
         assignLogExecutor.shutdownNow();
       }
     } catch (InterruptedException e) {

--- a/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProviderShutdownTest.java
+++ b/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/OpenFeatureLocalResolveProviderShutdownTest.java
@@ -1,0 +1,42 @@
+package com.spotify.confidence.sdk;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.openfeature.sdk.ImmutableContext;
+import java.io.File;
+import java.nio.file.Files;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class OpenFeatureLocalResolveProviderShutdownTest {
+
+  private static final String CLIENT_SECRET = "shutdown-test-secret";
+  private static final String ACCOUNT_NAME = "accounts/test-account";
+
+  @BeforeAll
+  static void beforeAll() {
+    System.setProperty("CONFIDENCE_NUMBER_OF_WASM_INSTANCES", "1");
+  }
+
+  @Test
+  void shutdownDoesNotWaitForTheNextScheduledPoll() throws Exception {
+    final byte[] stateBytes =
+        Files.readAllBytes(
+            new File(getClass().getResource("/resolver_state_current.pb").getPath()).toPath());
+
+    final OpenFeatureLocalResolveProvider provider =
+        new OpenFeatureLocalResolveProvider(
+            new TestAccountStateProvider(stateBytes, ACCOUNT_NAME),
+            CLIENT_SECRET,
+            new UnsupportedMaterializationStore(),
+            new NoOpWasmFlagLogger());
+
+    provider.initialize(new ImmutableContext());
+    provider.shutdown();
+
+    assertThat(provider.forcedFetcherShutdown)
+        .as(
+            "shutdown should drop the pending poll and terminate without force-killing the executor")
+        .isFalse();
+  }
+}


### PR DESCRIPTION
## Problem

In production the local provider logs this on essentially **every** pod termination:

```
com.spotify.confidence.sdk.OpenFeatureLocalResolveProvider: Flags fetcher executor did not terminate gracefully
```

Root cause: the flags-fetcher runs a poll task that reschedules itself, so there is always a poll pending in the future. `Executors.newScheduledThreadPool` returns a `ScheduledThreadPoolExecutor` whose `executeExistingDelayedTasksAfterShutdownPolicy` defaults to **true**, so `shutdown()` keeps that pending task and `awaitTermination` waits for a poll that won't fire for another ~15s. It times out and force-kills the executor — every time, not just when a poll is genuinely in flight.

## Fix

- Set `executeExistingDelayedTasksAfterShutdownPolicy(false)` on both schedulers, so `shutdown()` drops the pending poll and `awaitTermination` returns as soon as any actually-running task finishes.
- Bump the grace period from 1s to 5s so a poll caught genuinely mid-fetch (blocking CDN GET) or mid-state-push (WASM update across the pool) still gets a chance to finish before being forced.

Logs are unaffected — they're still flushed by `resolver.close()` / `flagLogger.shutdown()` after the executors stop.

## Test

`OpenFeatureLocalResolveProviderShutdownTest` initializes the provider (which schedules a poll) and immediately shuts down, asserting the fetcher terminates without being force-killed (`forcedFetcherShutdown == false`). This fails on the old behavior (the pending poll forces the timeout) and passes with the policy fix.

> The bundled `confidence_resolver.wasm` is git-ignored and built locally, so I can't run the resolver tests in my environment (no `wasm32` rust toolchain); they need CI. The change compiles.