### PR TITLE
fix(resolver): treat empty resolve token as no-op in apply_flags

### DIFF
--- a/confidence-resolver/src/lib.rs
+++ b/confidence-resolver/src/lib.rs
@@ -937,6 +937,13 @@ impl<'a, H: Host> AccountResolver<'a, H> {
     }
 
     pub fn apply_flags(&self, request: &flags_resolver::ApplyFlagsRequest) -> Result<(), String> {
+        // The Cloudflare edge resolver applies at resolve time (apply=true) and
+        // returns no resolve token, but SDKs still issue a background apply with
+        // an empty token. There is nothing to apply, so no-op instead of failing
+        // to decrypt an empty buffer.
+        if request.resolve_token.is_empty() {
+            return Ok(());
+        }
         let send_time_ts = request.send_time.as_ref().ok_or("send_time is required")?;
         let send_time = to_date_time_utc(send_time_ts).ok_or("invalid send_time")?;
         let receive_time: DateTime<Utc> = timestamp_to_datetime(&H::current_time())?;
@@ -2527,6 +2534,32 @@ mod tests {
                 .unwrap_err()
                 .contains("Flag in resolve token does not match"),
             "Error message should indicate flag mismatch"
+        );
+    }
+
+    #[test]
+    fn apply_flags_empty_resolve_token_is_noop() {
+        let state = ResolverState::from_proto(
+            EXAMPLE_STATE.to_owned().try_into().unwrap(),
+            "confidence-demo-june",
+            None,
+        )
+        .unwrap();
+
+        let context_json = r#"{"visitor_id": "tutorial_visitor"}"#;
+        let resolver: AccountResolver<'_, L> = state
+            .get_resolver_with_json_context(SECRET, context_json, &ENCRYPTION_KEY)
+            .unwrap();
+
+        let apply_request = flags_resolver::ApplyFlagsRequest {
+            resolve_token: vec![],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            resolver.apply_flags(&apply_request),
+            Ok(()),
+            "apply_flags should no-op when the resolve token is empty"
         );
     }
 


### PR DESCRIPTION
## Problem

The Cloudflare edge resolver forces `apply = true` on `flags:resolve` (`confidence-cloudflare-resolver/src/lib.rs`) and therefore returns no `resolveToken`. However, `@spotify-confidence/sdk` always resolves with `apply: false` and then issues a background `flags:apply` (there is no option to disable it), carrying an **empty** `resolve_token`.

`AccountResolver::apply_flags` calls `decrypt_resolve_token(&request.resolve_token)` unconditionally; on an empty buffer the decrypt reads bytes `0..16`, fails, and the Cloudflare handler returns **500**.

Following the [documented Cloudflare edge integration](https://confidence.spotify.com/docs/sdks/edge/cloudflare) verbatim (backend SDK + service binding), this returns 500 on essentially every background apply — millions per hour in our deployment. Exposures are unaffected (edge resolvers record apply data at resolve time, per the [apply-event docs](https://confidence.spotify.com/docs/sdks/apply-event)), so it is wasted invocations and error noise rather than data loss — but it is very high volume.

## Fix

An apply request with an empty `resolve_token` has no assignments to apply, so `apply_flags` returns `Ok(())` early instead of attempting to decrypt an empty buffer. Non-empty tokens are unchanged — a malformed/undecryptable token still errors.

## Test

Added `apply_flags_empty_resolve_token_is_noop`, which builds a resolver and asserts `apply_flags` returns `Ok(())` for an `ApplyFlagsRequest` with an empty `resolve_token`.
