### PR TITLE
fix(cloudflare): no-op apply when resolve token is empty

### DIFF
--- a/confidence-cloudflare-resolver/src/lib.rs
+++ b/confidence-cloudflare-resolver/src/lib.rs
@@ -331,6 +331,14 @@ pub async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
                             }
                         };
 
+                        // This resolver forces apply=true at resolve time and
+                        // returns no resolve token. SDKs still send a background
+                        // apply with an empty token — nothing to do.
+                        if apply_flag_req.resolve_token.is_empty() {
+                            return Response::from_json(&ApplyFlagsResponse::default())?
+                                .with_cors_headers(&allowed_origin);
+                        }
+
                         match state.get_resolver::<H>(
                             &apply_flag_req.client_secret,
                             Struct::default(),


### PR DESCRIPTION
## Summary
- Short-circuits the `flags:apply` handler in the CF resolver when `resolve_token` is empty, returning an empty `ApplyFlagsResponse` instead of attempting to decrypt an empty buffer.

Alternative to #432 — scopes the fix to the Cloudflare harness where the problem originates, rather than the core resolver.

Closes #432 

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>