### PR TITLE
fix(cloudflare): no-op apply and telemetry for service binding SDKs

### DIFF
--- a/confidence-cloudflare-resolver/deployer/README.md
+++ b/confidence-cloudflare-resolver/deployer/README.md
@@ -119,7 +119,62 @@ When integrating with the Cloudflare resolver, you have two options:
 
 **HTTP calls**: Standard HTTP requests to the resolver endpoint. Use this approach when calling from external services or client applications.
 
-For more details on integration, including code examples using the [`@spotify-confidence/sdk`](https://github.com/spotify/confidence-sdk-js), see the [Confidence documentation](https://confidence.spotify.com/docs/sdks/edge/cloudflare#cloudflare-workers).
+### Example: Service binding with `@spotify-confidence/sdk`
+
+1. Add a service binding to your `wrangler.json`:
+
+```json
+{
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-02-04",
+  "services": [
+    {
+      "binding": "ConfidenceBinding",
+      "service": "confidence-cloudflare-resolver"
+    }
+  ]
+}
+```
+
+2. Use the SDK with `fetchImplementation` and `waitUntil`:
+
+```typescript
+import { Confidence } from '@spotify-confidence/sdk';
+
+interface Env {
+  CONFIDENCE_CLIENT_SECRET: string;
+  ConfidenceBinding: {
+    fetch: (request: Request) => Promise<Response>;
+  };
+}
+
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    const confidence = Confidence.create({
+      clientSecret: env.CONFIDENCE_CLIENT_SECRET,
+      environment: 'backend',
+      fetchImplementation: (req: Request) => env.ConfidenceBinding.fetch(req),
+      timeout: 1000,
+      waitUntil: (p) => ctx.waitUntil(p),
+    });
+
+    const flag = await confidence
+      .withContext({ targeting_key: 'user-123' })
+      .evaluateFlag('my-flag', {});
+
+    return new Response(JSON.stringify({ flag }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+- **`fetchImplementation`** routes resolve requests through the service binding instead of the public internet.
+- **`waitUntil`** keeps the Worker alive for background tasks (apply events, telemetry) after the response is sent. Without it, these fire-and-forget calls are silently dropped.
+- **`environment: 'backend'`** is required for server-side usage.
+
+For more details, see the [Confidence documentation](https://confidence.spotify.com/docs/sdks/edge/cloudflare#cloudflare-workers).
 
 ## Telemetry & Metrics
 

--- a/confidence-cloudflare-resolver/src/lib.rs
+++ b/confidence-cloudflare-resolver/src/lib.rs
@@ -331,6 +331,14 @@ pub async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
                             }
                         };
 
+                        // This resolver forces apply=true at resolve time and
+                        // returns no resolve token. Some SDKs still send a background
+                        // apply with an empty token — nothing to do.
+                        if apply_flag_req.resolve_token.is_empty() {
+                            return Response::from_json(&ApplyFlagsResponse::default())?
+                                .with_cors_headers(&allowed_origin);
+                        }
+
                         match state.get_resolver::<H>(
                             &apply_flag_req.client_secret,
                             Struct::default(),
@@ -346,6 +354,9 @@ pub async fn main(req: Request, env: Env, ctx: Context) -> Result<Response> {
                                 Response::error(msg, 500)?.with_cors_headers(&allowed_origin)
                             }
                         }
+                    }
+                    "telemetry:upload" => {
+                        Response::ok("")?.with_cors_headers(&allowed_origin)
                     }
                     _ => Response::error("Not found", 404)?.with_cors_headers(&allowed_origin),
                 }


### PR DESCRIPTION
## Summary

- Short-circuit `flags:apply` with 200 when `resolve_token` is empty — the resolver already applies at resolve time (`apply=true`), so the background apply SDKs send is redundant and was causing 500s when trying to decrypt an empty token
- Add no-op `telemetry:upload` route — SDKs using service bindings route all requests through the resolver, including telemetry which has no route (404)
- Add service binding integration example with `waitUntil` to deployer README

Closes #432

## Test plan

- [x] Deployed fixed resolver to Cloudflare test account
- [x] Verified `flags:apply` with empty token returns 200
- [x] Verified `telemetry:upload` returns 200
- [x] Verified full SDK flow (resolve + apply) via service binding returns all 200s
- [x] Verified resolve still works correctly (`MATCH` with expected variant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)