### PR TITLE
fix(python): avoid mutating caller context for skip-apply

### DIFF
--- a/openfeature-provider/python/src/confidence/provider.py
+++ b/openfeature-provider/python/src/confidence/provider.py
@@ -456,7 +456,7 @@ class ConfidenceProvider(AbstractProvider):
             skip_apply = False
             if evaluation_context and evaluation_context.attributes:
                 skip_apply = (
-                    evaluation_context.attributes.pop("_confidence_skip_apply", False)
+                    evaluation_context.attributes.get("_confidence_skip_apply", False)
                     is True
                 )
 
@@ -870,9 +870,11 @@ class ConfidenceProvider(AbstractProvider):
                 string_value=context.targeting_key
             )
 
-        # Add attributes
+        # Add attributes, skipping the internal apply-control flag
         if context.attributes:
             for key, value in context.attributes.items():
+                if key == "_confidence_skip_apply":
+                    continue
                 fields[key] = ConfidenceProvider._value_to_proto(value)
 
         return struct_pb2.Struct(fields=fields)

--- a/openfeature-provider/python/tests/test_provider.py
+++ b/openfeature-provider/python/tests/test_provider.py
@@ -883,14 +883,18 @@ class TestSkipApply:
         finally:
             provider.shutdown()
 
-    def test_skip_apply_key_is_stripped_from_context(
+    def test_skip_apply_does_not_mutate_caller_context(
         self,
         wasm_bytes: bytes,
         test_resolver_state: bytes,
         test_account_id: str,
         test_client_secret: str,
     ) -> None:
-        """Test that _confidence_skip_apply is removed from attributes after resolve."""
+        """Test that _confidence_skip_apply is left intact on the caller's context.
+
+        The key must not be popped from the caller's attributes, otherwise a
+        reused EvaluationContext would only skip apply on its first evaluation.
+        """
         mock_fetcher = MockStateFetcher(test_resolver_state, test_account_id)
         mock_logger = MockFlagLogger()
 
@@ -912,12 +916,15 @@ class TestSkipApply:
                 targeting_key="test-user",
                 attributes=attrs,
             )
-            provider.resolve_string_details(
-                flag_key="tutorial-feature.message",
-                default_value="default-message",
-                evaluation_context=ctx,
-            )
 
-            assert "_confidence_skip_apply" not in attrs
+            # Resolve twice with the same context to ensure skip_apply is
+            # honored consistently and the key is never stripped.
+            for _ in range(2):
+                provider.resolve_string_details(
+                    flag_key="tutorial-feature.message",
+                    default_value="default-message",
+                    evaluation_context=ctx,
+                )
+                assert attrs["_confidence_skip_apply"] is True
         finally:
             provider.shutdown()


### PR DESCRIPTION
## Summary

- `ConfidenceProvider._resolve_object` extracted `_confidence_skip_apply` with `evaluation_context.attributes.pop(...)`, which **mutates the caller's `EvaluationContext` in place**. If a caller reuses the same context across multiple evaluations, the key is stripped on the first call, so subsequent calls see it missing and send `apply=True` — silently breaking apply suppression after the first resolve.
- Switched to a non-mutating `attributes.get(...)` read, and filter the internal `_confidence_skip_apply` key out when building the proto context (in `_context_to_proto`) so it still never reaches the resolver.
- This matches what every other provider already does (JS destructures, Go deletes from a copied map, Java reads then filters in `convertToProto`, Rust `.remove()`s a clone).

Originally surfaced in review of #431, but the bug was introduced in #421 (commit `0ad63cc`) and only affects the Python provider, so it's fixed here separately.

## Test plan

- Replaced `test_skip_apply_key_is_stripped_from_context` (which asserted the buggy mutation) with `test_skip_apply_does_not_mutate_caller_context`, which resolves twice with the same context and asserts the key remains intact across calls.
- `python3 -m py_compile` passes on both edited files.
- Note: full `make test` requires building the WASM artifact (no local Rust toolchain in this environment); CI will exercise the suite.

Made with [Cursor](https://cursor.com)