### PR TITLE
fix(python): use set_provider_and_wait for openfeature-sdk 0.10.0

### DIFF
--- a/openfeature-provider/python/README.md
+++ b/openfeature-provider/python/README.md
@@ -15,7 +15,7 @@ A high-performance OpenFeature provider for [Confidence](https://confidence.spot
 ## Requirements
 
 - Python 3.10+
-- OpenFeature SDK 0.8.0+
+- OpenFeature SDK 0.10.0+
 
 ## Installation
 
@@ -42,7 +42,7 @@ from confidence import ConfidenceProvider
 
 # Create and register the provider
 provider = ConfidenceProvider(client_secret="your-client-secret")
-api.set_provider(provider)
+api.set_provider_and_wait(provider)
 
 # Get a client
 client = api.get_client()

--- a/openfeature-provider/python/pyproject.toml
+++ b/openfeature-provider/python/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "openfeature-sdk>=0.8.0",
+    "openfeature-sdk>=0.10.0",
     "wasmtime>=28.0.0",
     "protobuf>=5.0.0",
     "grpcio>=1.60.0",

--- a/openfeature-provider/python/tests/e2e_test.py
+++ b/openfeature-provider/python/tests/e2e_test.py
@@ -1,6 +1,7 @@
 """End-to-end tests that verify flag resolution with the real backend."""
 
 from openfeature import api
+from openfeature.api import set_provider_and_wait
 from openfeature.evaluation_context import EvaluationContext
 
 import os
@@ -24,8 +25,7 @@ class TestFlagResolveWithRemoteMaterializationStore:
         )
 
         try:
-            provider.initialize(EvaluationContext())
-            api.set_provider(provider)
+            set_provider_and_wait(provider)
             client = api.get_client()
 
             # Use targetless context with only user_id, matching Go tests
@@ -55,8 +55,7 @@ class TestFlagResolveWithRemoteMaterializationStore:
         )
 
         try:
-            provider.initialize(EvaluationContext())
-            api.set_provider(provider)
+            set_provider_and_wait(provider)
             client = api.get_client()
 
             # Use targetless context with only user_id, matching Go tests
@@ -90,8 +89,7 @@ class TestFlagResolveWithoutMaterializationStore:
         )
 
         try:
-            provider.initialize(EvaluationContext())
-            api.set_provider(provider)
+            set_provider_and_wait(provider)
             client = api.get_client()
 
             ctx = EvaluationContext(

--- a/openfeature-provider/python/tests/flaglogs_e2e_test.py
+++ b/openfeature-provider/python/tests/flaglogs_e2e_test.py
@@ -3,6 +3,7 @@
 import time
 
 from openfeature import api
+from openfeature.api import set_provider_and_wait
 from openfeature.evaluation_context import EvaluationContext
 
 import os
@@ -24,8 +25,7 @@ class TestFlagLogging:
         )
 
         try:
-            provider.initialize(EvaluationContext())
-            api.set_provider(provider)
+            set_provider_and_wait(provider)
             client = api.get_client()
 
             # Perform multiple resolves to generate logs
@@ -56,8 +56,7 @@ class TestFlagLogging:
         )
 
         try:
-            provider.initialize(EvaluationContext())
-            api.set_provider(provider)
+            set_provider_and_wait(provider)
             client = api.get_client()
 
             # Resolve a flag
@@ -102,8 +101,7 @@ class TestAssignmentLogging:
         )
 
         try:
-            provider.initialize(EvaluationContext())
-            api.set_provider(provider)
+            set_provider_and_wait(provider)
             client = api.get_client()
 
             ctx = EvaluationContext(


### PR DESCRIPTION
## Summary
- `openfeature-sdk` 0.10.0 made `set_provider()` non-blocking, causing `PROVIDER_NOT_READY` errors in e2e tests
- Switches all e2e tests to `set_provider_and_wait()` and removes redundant explicit `initialize()` calls
- Bumps minimum `openfeature-sdk` to `>=0.10.0`
- Updates README Quick Start example
