### PR TITLE
feat(resolver): add IsNullRule targeting operator

### DIFF
--- a/confidence-resolver/protos/confidence/flags/types/v1/target.proto
+++ b/confidence-resolver/protos/confidence/flags/types/v1/target.proto
@@ -30,6 +30,7 @@ message Targeting {
         AllRule all_rule = 6;
         StartsWithRule starts_with_rule = 7;
         EndsWithRule ends_with_rule = 8;
+        IsNullRule is_null_rule = 9;
       }
     }
 
@@ -100,6 +101,11 @@ message Targeting {
   message EndsWithRule {
     string value = 1;
   }
+
+  // matches if the attribute value is null or absent from the evaluation
+  // context. "is not null" is expressed by wrapping the criterion reference in
+  // Expression.not.
+  message IsNullRule {}
 
   // equality (==, !=, ∈) defined for all types
   // comparison (<, <=, >, >=) defined for number, timestamp, version

--- a/confidence-resolver/src/lib.rs
+++ b/confidence-resolver/src/lib.rs
@@ -1393,9 +1393,19 @@ impl<'a, H: Host> AccountResolver<'a, H> {
             };
             match &criterion {
                 criterion::Criterion::Attribute(attribute_criterion) => {
-                    let expected_value_type = value::expected_value_type(attribute_criterion);
                     let attribute_value =
                         self.get_attribute_value(&attribute_criterion.attribute_name);
+
+                    if matches!(
+                        attribute_criterion.rule,
+                        Some(criterion::attribute_criterion::Rule::IsNullRule(_))
+                    ) {
+                        let is_null =
+                            matches!(attribute_value.kind, None | Some(Kind::NullValue(_)));
+                        return Ok(Some(is_null));
+                    }
+
+                    let expected_value_type = value::expected_value_type(attribute_criterion);
                     let converted =
                         value::convert_to_targeting_value(attribute_value, expected_value_type)?;
                     let wrapped = list_wrapper(&converted);

--- a/confidence-resolver/src/resolver_spec_tests.rs
+++ b/confidence-resolver/src/resolver_spec_tests.rs
@@ -577,6 +577,11 @@ spec_test!(is_null_implicit);
 spec_test!(is_null_non_null_value);
 spec_test!(is_not_null_with_value);
 spec_test!(is_not_null_missing);
+spec_test!(is_null_rule_explicit);
+spec_test!(is_null_rule_implicit);
+spec_test!(is_null_rule_non_null_value);
+spec_test!(is_not_null_rule_with_value);
+spec_test!(is_not_null_rule_missing);
 
 // NOT any rule
 spec_test!(not_any_no_overlap);

--- a/confidence-resolver/src/value.rs
+++ b/confidence-resolver/src/value.rs
@@ -438,6 +438,7 @@ impl ExpectedValueType for targeting::criterion::AttributeCriterion {
             }
             criterion::attribute_criterion::Rule::StartsWithRule(_)
             | criterion::attribute_criterion::Rule::EndsWithRule(_) => Some(&STRING_VALUE_TYPE),
+            criterion::attribute_criterion::Rule::IsNullRule(_) => None,
         }
     }
 }

--- a/confidence-resolver/test-payloads/resolver-spec/state.json
+++ b/confidence-resolver/test-payloads/resolver-spec/state.json
@@ -1766,6 +1766,58 @@
         }
       ]
     },
+    "flags/is-null-rule-flag": {
+      "name": "flags/is-null-rule-flag",
+      "state": "ACTIVE",
+      "clients": ["clients/test-client"],
+      "variants": [
+        { "name": "on", "value": { "enabled": true } }
+      ],
+      "rules": [
+        {
+          "name": "flags/is-null-rule-flag/rules/rule1",
+          "segment": "segments/is-null-rule",
+          "enabled": true,
+          "targetingKeySelector": "targeting_key",
+          "assignmentSpec": {
+            "bucketCount": 1000,
+            "assignments": [
+              {
+                "assignmentId": "a1",
+                "variant": { "variant": "on" },
+                "bucketRanges": [{ "lower": 0, "upper": 1000 }]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "flags/is-not-null-rule-flag": {
+      "name": "flags/is-not-null-rule-flag",
+      "state": "ACTIVE",
+      "clients": ["clients/test-client"],
+      "variants": [
+        { "name": "on", "value": { "enabled": true } }
+      ],
+      "rules": [
+        {
+          "name": "flags/is-not-null-rule-flag/rules/rule1",
+          "segment": "segments/is-not-null-rule",
+          "enabled": true,
+          "targetingKeySelector": "targeting_key",
+          "assignmentSpec": {
+            "bucketCount": 1000,
+            "assignments": [
+              {
+                "assignmentId": "a1",
+                "variant": { "variant": "on" },
+                "bucketRanges": [{ "lower": 0, "upper": 1000 }]
+              }
+            ]
+          }
+        }
+      ]
+    },
     "flags/not-any-flag": {
       "name": "flags/not-any-flag",
       "state": "ACTIVE",
@@ -2572,6 +2624,36 @@
         "expression": { "not": { "ref": "c1" } }
       }
     },
+    "segments/is-null-rule": {
+      "name": "segments/is-null-rule",
+      "state": "OK",
+      "targeting": {
+        "criteria": {
+          "c1": {
+            "attribute": {
+              "attributeName": "null-attribute",
+              "isNullRule": {}
+            }
+          }
+        },
+        "expression": { "ref": "c1" }
+      }
+    },
+    "segments/is-not-null-rule": {
+      "name": "segments/is-not-null-rule",
+      "state": "OK",
+      "targeting": {
+        "criteria": {
+          "c1": {
+            "attribute": {
+              "attributeName": "null-attribute",
+              "isNullRule": {}
+            }
+          }
+        },
+        "expression": { "not": { "ref": "c1" } }
+      }
+    },
     "segments/not-any-rule": {
       "name": "segments/not-any-rule",
       "state": "OK",
@@ -2756,6 +2838,8 @@
     "segments/catch-all": "ALL",
     "segments/is-null": "ALL",
     "segments/is-not-null": "ALL",
+    "segments/is-null-rule": "ALL",
+    "segments/is-not-null-rule": "ALL",
     "segments/not-any-rule": "ALL",
     "segments/not-all-rule": "ALL",
     "segments/semver-range": "ALL",

--- a/confidence-resolver/test-payloads/resolver-spec/tests.json
+++ b/confidence-resolver/test-payloads/resolver-spec/tests.json
@@ -2655,6 +2655,145 @@
     }
   },
   {
+    "name": "is_null_rule_explicit",
+    "resolveRequest": {
+      "flags": [
+        "flags/is-null-rule-flag"
+      ],
+      "evaluationContext": {
+        "targeting_key": "user1",
+        "null-attribute": null
+      },
+      "clientSecret": "test-secret"
+    },
+    "expectedResult": {
+      "general": {
+        "resolvedFlags": [
+          {
+            "flag": "flags/is-null-rule-flag",
+            "reason": "RESOLVE_REASON_MATCH",
+            "variant": "on",
+            "value": {
+              "enabled": true
+            },
+            "shouldApply": true
+          }
+        ],
+        "expectError": null
+      }
+    }
+  },
+  {
+    "name": "is_null_rule_implicit",
+    "resolveRequest": {
+      "flags": [
+        "flags/is-null-rule-flag"
+      ],
+      "evaluationContext": {
+        "targeting_key": "user1"
+      },
+      "clientSecret": "test-secret"
+    },
+    "expectedResult": {
+      "general": {
+        "resolvedFlags": [
+          {
+            "flag": "flags/is-null-rule-flag",
+            "reason": "RESOLVE_REASON_MATCH",
+            "variant": "on",
+            "value": {
+              "enabled": true
+            },
+            "shouldApply": true
+          }
+        ],
+        "expectError": null
+      }
+    }
+  },
+  {
+    "name": "is_null_rule_non_null_value",
+    "resolveRequest": {
+      "flags": [
+        "flags/is-null-rule-flag"
+      ],
+      "evaluationContext": {
+        "targeting_key": "user1",
+        "null-attribute": "hello"
+      },
+      "clientSecret": "test-secret"
+    },
+    "expectedResult": {
+      "general": {
+        "resolvedFlags": [
+          {
+            "flag": "flags/is-null-rule-flag",
+            "reason": "RESOLVE_REASON_NO_SEGMENT_MATCH",
+            "variant": "",
+            "value": null,
+            "shouldApply": false
+          }
+        ],
+        "expectError": null
+      }
+    }
+  },
+  {
+    "name": "is_not_null_rule_with_value",
+    "resolveRequest": {
+      "flags": [
+        "flags/is-not-null-rule-flag"
+      ],
+      "evaluationContext": {
+        "targeting_key": "user1",
+        "null-attribute": "hello"
+      },
+      "clientSecret": "test-secret"
+    },
+    "expectedResult": {
+      "general": {
+        "resolvedFlags": [
+          {
+            "flag": "flags/is-not-null-rule-flag",
+            "reason": "RESOLVE_REASON_MATCH",
+            "variant": "on",
+            "value": {
+              "enabled": true
+            },
+            "shouldApply": true
+          }
+        ],
+        "expectError": null
+      }
+    }
+  },
+  {
+    "name": "is_not_null_rule_missing",
+    "resolveRequest": {
+      "flags": [
+        "flags/is-not-null-rule-flag"
+      ],
+      "evaluationContext": {
+        "targeting_key": "user1"
+      },
+      "clientSecret": "test-secret"
+    },
+    "expectedResult": {
+      "general": {
+        "resolvedFlags": [
+          {
+            "flag": "flags/is-not-null-rule-flag",
+            "reason": "RESOLVE_REASON_NO_SEGMENT_MATCH",
+            "variant": "",
+            "value": null,
+            "shouldApply": false
+          }
+        ],
+        "expectError": null
+      }
+    }
+  },
+  {
     "name": "not_any_no_overlap",
     "resolveRequest": {
       "flags": [


### PR DESCRIPTION
## Summary
- Adds a first-class `IsNullRule` member to the `AttributeCriterion.rule` oneof for "is null" / "is not null" targeting.
- Matched by oneof presence → attribute value is null/absent; "is not null" stays `Expression.not(ref)`.

## Why
"Is null"/"is not null" was encoded as an `EqRule` with an empty `Value` sentinel, which is indistinguishable from "unset" across generic proto/JSON transcoding and could be dropped in transit, causing the rule to arrive unset and the segment to be skipped.

This is the Rust mirror of the Java resolver change, keeping the two implementations in sync per the cross-implementation conformance contract.

## Test plan
- [x] `cargo test resolver_spec` — 135 pass (incl. 5 new `is_null_rule_*` / `is_not_null_rule_*` cases in `test-payloads/resolver-spec`)
- [x] `cargo test` — 362 unit tests pass

Made with [Cursor](https://cursor.com)