### PR TITLE
feat(js): publish flag evaluations to window global for session recording

### DIFF
--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
@@ -18,7 +18,6 @@ import {
 import { SetResolverStateRequest } from './proto/confidence/wasm/messages';
 import FlagBundleType, * as FlagBundle from './flag-bundle';
 import { ErrorCode, ResolutionDetails } from './types';
-import { publishFlagEvaluation } from './flag-evaluation-global';
 
 type FlagBundle = FlagBundleType;
 const logger = getLogger('provider');
@@ -225,10 +224,6 @@ export class ConfidenceServerProviderLocal implements Provider {
         resolution = FlagBundle.error(ErrorCode.GENERAL, String(err));
       }
       const result = FlagBundle.resolve(resolution, flagKey, defaultValue, logger);
-
-      if (result.reason === 'MATCH' && result.variant) {
-        publishFlagEvaluation(`flags/${flagName}`, result.variant);
-      }
 
       const latencyUs = Math.round((performance.now() - startMs) * 1000);
       let reason: ResolveReason;

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
@@ -18,6 +18,7 @@ import {
 import { SetResolverStateRequest } from './proto/confidence/wasm/messages';
 import FlagBundleType, * as FlagBundle from './flag-bundle';
 import { ErrorCode, ResolutionDetails } from './types';
+import { publishFlagEvaluation } from './flag-evaluation-global';
 
 type FlagBundle = FlagBundleType;
 const logger = getLogger('provider');
@@ -224,6 +225,10 @@ export class ConfidenceServerProviderLocal implements Provider {
         resolution = FlagBundle.error(ErrorCode.GENERAL, String(err));
       }
       const result = FlagBundle.resolve(resolution, flagKey, defaultValue, logger);
+
+      if (result.reason === 'MATCH' && result.variant) {
+        publishFlagEvaluation(`flags/${flagName}`, result.variant);
+      }
 
       const latencyUs = Math.round((performance.now() - startMs) * 1000);
       let reason: ResolveReason;

--- a/openfeature-provider/js/src/flag-evaluation-global.test.ts
+++ b/openfeature-provider/js/src/flag-evaluation-global.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { publishFlagEvaluation } from './flag-evaluation-global';
+
+describe('publishFlagEvaluation', () => {
+  let originalWindow: typeof globalThis.window;
+
+  beforeEach(() => {
+    originalWindow = globalThis.window;
+  });
+
+  afterEach(() => {
+    if (originalWindow === undefined) {
+      // @ts-expect-error restoring undefined
+      delete globalThis.window;
+    } else {
+      globalThis.window = originalWindow;
+    }
+  });
+
+  it('writes flag evaluation to window.__confidence.flags', () => {
+    globalThis.window = {} as any;
+
+    publishFlagEvaluation('flags/my-flag', 'flags/my-flag/variants/treatment');
+
+    expect((window as any).__confidence.flags['flags/my-flag']).toEqual({
+      variant: 'flags/my-flag/variants/treatment',
+    });
+  });
+
+  it('initializes __confidence and flags if missing', () => {
+    globalThis.window = {} as any;
+
+    publishFlagEvaluation('flags/test', 'flags/test/variants/control');
+
+    expect((window as any).__confidence).toBeDefined();
+    expect((window as any).__confidence.flags).toBeDefined();
+    expect((window as any).__confidence.flags['flags/test']).toEqual({
+      variant: 'flags/test/variants/control',
+    });
+  });
+
+  it('preserves existing __confidence object', () => {
+    const existing = { other: 'data' };
+    globalThis.window = { __confidence: existing } as any;
+
+    publishFlagEvaluation('flags/my-flag', 'flags/my-flag/variants/treatment');
+
+    expect((window as any).__confidence.other).toBe('data');
+    expect((window as any).__confidence.flags['flags/my-flag']).toEqual({
+      variant: 'flags/my-flag/variants/treatment',
+    });
+  });
+
+  it('preserves existing flags object (e.g. recorder Proxy)', () => {
+    const flags = { 'flags/existing': { variant: 'flags/existing/variants/a' } };
+    globalThis.window = { __confidence: { flags } } as any;
+
+    publishFlagEvaluation('flags/new-flag', 'flags/new-flag/variants/b');
+
+    expect((window as any).__confidence.flags['flags/existing']).toEqual({
+      variant: 'flags/existing/variants/a',
+    });
+    expect((window as any).__confidence.flags['flags/new-flag']).toEqual({
+      variant: 'flags/new-flag/variants/b',
+    });
+    expect((window as any).__confidence.flags).toBe(flags);
+  });
+
+  it('deduplicates: skips write when variant unchanged', () => {
+    const flags: Record<string, { variant: string }> = {};
+    globalThis.window = { __confidence: { flags } } as any;
+
+    const setter = vi.fn();
+    Object.defineProperty(flags, 'flags/my-flag', {
+      get: () => ({ variant: 'flags/my-flag/variants/treatment' }),
+      set: setter,
+      configurable: true,
+    });
+
+    publishFlagEvaluation('flags/my-flag', 'flags/my-flag/variants/treatment');
+
+    expect(setter).not.toHaveBeenCalled();
+  });
+
+  it('writes when variant changes', () => {
+    globalThis.window = {
+      __confidence: {
+        flags: { 'flags/my-flag': { variant: 'flags/my-flag/variants/control' } },
+      },
+    } as any;
+
+    publishFlagEvaluation('flags/my-flag', 'flags/my-flag/variants/treatment');
+
+    expect((window as any).__confidence.flags['flags/my-flag']).toEqual({
+      variant: 'flags/my-flag/variants/treatment',
+    });
+  });
+
+  it('is a no-op when window is undefined', () => {
+    // @ts-expect-error simulating server-side
+    delete globalThis.window;
+
+    expect(() => {
+      publishFlagEvaluation('flags/my-flag', 'flags/my-flag/variants/treatment');
+    }).not.toThrow();
+  });
+});

--- a/openfeature-provider/js/src/flag-evaluation-global.ts
+++ b/openfeature-provider/js/src/flag-evaluation-global.ts
@@ -1,15 +1,5 @@
-interface ConfidenceFlagEntry {
-  variant: string;
-}
-
 interface ConfidenceGlobal {
-  flags?: Record<string, ConfidenceFlagEntry>;
-}
-
-declare global {
-  interface Window {
-    __confidence?: ConfidenceGlobal;
-  }
+  flags?: Record<string, { variant: string }>;
 }
 
 export function publishFlagEvaluation(name: string, variant: string): void {

--- a/openfeature-provider/js/src/flag-evaluation-global.ts
+++ b/openfeature-provider/js/src/flag-evaluation-global.ts
@@ -1,12 +1,22 @@
-declare const window: { __confidence?: { flags?: Record<string, { variant: string }> } } | undefined;
+interface ConfidenceFlagEntry {
+  variant: string;
+}
+
+interface ConfidenceGlobal {
+  flags?: Record<string, ConfidenceFlagEntry>;
+}
+
+declare global {
+  interface Window {
+    __confidence?: ConfidenceGlobal;
+  }
+}
 
 export function publishFlagEvaluation(name: string, variant: string): void {
   if (typeof window === 'undefined') return;
-
-  const confidence = (window.__confidence ??= {});
-  const flags = (confidence.flags ??= {});
-
-  if (flags[name]?.variant === variant) return;
-
-  flags[name] = { variant };
+  (window as any).__confidence ??= {};
+  const confidence = (window as any).__confidence as ConfidenceGlobal;
+  confidence.flags ??= {};
+  if (confidence.flags[name]?.variant === variant) return;
+  confidence.flags[name] = { variant };
 }

--- a/openfeature-provider/js/src/flag-evaluation-global.ts
+++ b/openfeature-provider/js/src/flag-evaluation-global.ts
@@ -1,0 +1,12 @@
+declare const window: { __confidence?: { flags?: Record<string, { variant: string }> } } | undefined;
+
+export function publishFlagEvaluation(name: string, variant: string): void {
+  if (typeof window === 'undefined') return;
+
+  const confidence = (window.__confidence ??= {});
+  const flags = (confidence.flags ??= {});
+
+  if (flags[name]?.variant === variant) return;
+
+  flags[name] = { variant };
+}

--- a/openfeature-provider/js/src/react/client.test.tsx
+++ b/openfeature-provider/js/src/react/client.test.tsx
@@ -22,6 +22,7 @@ describe('useFlag', () => {
 
   beforeEach(() => {
     mockApply = vi.fn().mockResolvedValue(undefined);
+    delete (window as any).__confidence;
   });
 
   const wrapper =
@@ -143,6 +144,19 @@ describe('useFlag', () => {
 
       expect(mockApply).toHaveBeenCalledTimes(1);
       expect(mockApply).toHaveBeenCalledWith('my-flag');
+      expect((window as any).__confidence?.flags?.['flags/my-flag']).toEqual({ variant: 'x' });
+    });
+
+    it('does not publish flag evaluation when variant is missing', () => {
+      const bundle = createTestBundle({
+        'no-variant-flag': { value: { value: 'hello' }, reason: 'NO_SEGMENT_MATCH', shouldApply: false },
+      });
+
+      renderHook(() => useFlag('no-variant-flag.value', 'default'), {
+        wrapper: wrapper(bundle),
+      });
+
+      expect((window as any).__confidence?.flags?.['flags/no-variant-flag']).toBeUndefined();
     });
 
     it('does not call apply on mount when shouldApply is false', () => {

--- a/openfeature-provider/js/src/react/client.tsx
+++ b/openfeature-provider/js/src/react/client.tsx
@@ -6,6 +6,7 @@ import type FlagBundleType from '../flag-bundle';
 import * as FlagBundle from '../flag-bundle';
 import { devWarn } from '../util';
 import { ErrorCode } from '../types';
+import { publishFlagEvaluation } from '../flag-evaluation-global';
 
 type FlagBundle = FlagBundleType;
 
@@ -168,6 +169,12 @@ export function useFlagDetails<T extends FlagValue>(
       doExpose();
     }
   }, [autoExpose, doExpose]);
+
+  useEffect(() => {
+    if (resolution.reason === 'MATCH' && resolution.variant) {
+      publishFlagEvaluation(`flags/${baseFlagName}`, resolution.variant);
+    }
+  }, [baseFlagName, resolution.reason, resolution.variant]);
 
   // Expose function returned to caller
   const expose = useCallback(() => {

--- a/openfeature-provider/js/src/react/client.tsx
+++ b/openfeature-provider/js/src/react/client.tsx
@@ -161,7 +161,7 @@ export function useFlagDetails<T extends FlagValue>(
     if (resolution.shouldApply) {
       ctx?.apply(baseFlagName);
     }
-    if(resolution.variant) {
+    if (resolution.variant) {
       publishFlagEvaluation(`flags/${baseFlagName}`, resolution.variant);
     }
   }, [ctx, baseFlagName, resolution.shouldApply, resolution.variant]);

--- a/openfeature-provider/js/src/react/client.tsx
+++ b/openfeature-provider/js/src/react/client.tsx
@@ -161,7 +161,10 @@ export function useFlagDetails<T extends FlagValue>(
     if (resolution.shouldApply) {
       ctx?.apply(baseFlagName);
     }
-  }, [ctx, baseFlagName, resolution.shouldApply]);
+    if(resolution.variant) {
+      publishFlagEvaluation(`flags/${baseFlagName}`, resolution.variant);
+    }
+  }, [ctx, baseFlagName, resolution.shouldApply, resolution.variant]);
 
   // Auto exposure effect
   useEffect(() => {
@@ -169,12 +172,6 @@ export function useFlagDetails<T extends FlagValue>(
       doExpose();
     }
   }, [autoExpose, doExpose]);
-
-  useEffect(() => {
-    if (resolution.reason === 'MATCH' && resolution.variant) {
-      publishFlagEvaluation(`flags/${baseFlagName}`, resolution.variant);
-    }
-  }, [baseFlagName, resolution.reason, resolution.variant]);
 
   // Expose function returned to caller
   const expose = useCallback(() => {


### PR DESCRIPTION
## Summary
- Adds `publishFlagEvaluation` that writes to `window.__confidence.flags` on MATCH evaluations, enabling the session recorder to observe flag assignments and emit `csr:flagEvaluation` plugin events.
- Mirrors the pattern from [confidence-sdk-js#369](https://github.com/spotify/confidence-sdk-js/pull/369).

## Test plan
- [x] Unit tests for `publishFlagEvaluation` (SSR safety, dedup, object preservation)
- [x] Existing test suites pass (59 tests)
- [x] TypeScript type check clean
- [x] Verified end-to-end in a local Next.js app: evaluated `hawkflag` and `tutorial-flag` via the WASM resolver, hydrated results to `window.__confidence.flags` on the client, and confirmed a Proxy-based mock session recorder observed the writes as `csr:flagEvaluation` events. Also tested lazy mount — hid one flag behind a button to verify the global is only written when the component mounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)