### PR TITLE
fix(ruby): remove redundant keyword_init from Struct definitions

### DIFF
--- a/openfeature-provider/ruby/lib/confidence/openfeature/api_client.rb
+++ b/openfeature-provider/ruby/lib/confidence/openfeature/api_client.rb
@@ -84,7 +84,7 @@ module Confidence
       end
     end
 
-    ResolvedFlag = Struct.new(:flag, :variant, :value, keyword_init: true) do
+    ResolvedFlag = Struct.new(:flag, :variant, :value) do
       def empty?
         variant.nil? || value.nil?
       end

--- a/openfeature-provider/ruby/lib/confidence/openfeature/provider.rb
+++ b/openfeature-provider/ruby/lib/confidence/openfeature/provider.rb
@@ -12,8 +12,7 @@ module Confidence
       # Error_code and error_message seemingly not used by OpenFeature SDK.
       # Including here for compatibility.
       ResolutionDetails = Struct.new(
-        :value, :reason, :variant, :error_code, :error_message,
-        keyword_init: true
+        :value, :reason, :variant, :error_code, :error_message
       )
 
       def initialize(api_client:, apply_on_resolve: true)


### PR DESCRIPTION
## Summary
- Remove redundant `keyword_init: true` from `ResolvedFlag` and `ResolutionDetails` Struct definitions
- Fixes `Style/RedundantStructKeywordInit` lint violations

## Test plan
- [x] Ruby lint passes (`make lint` in `openfeature-provider/ruby/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)