### PR TITLE
fix(resolver): support explicit null_value for is null / is not null

### DIFF
--- a/confidence-resolver/protos/confidence/flags/types/v1/target.proto
+++ b/confidence-resolver/protos/confidence/flags/types/v1/target.proto
@@ -111,6 +111,11 @@ message Targeting {
       google.protobuf.Timestamp timestamp_value = 5;
       SemanticVersion version_value = 6;
       ListValue list_value = 8;
+      // Explicit null value. An EqRule against this matches when the attribute
+      // is null or absent ("is null"); "is not null" wraps it in Expression.not.
+      // Set to true so the value is non-empty on the wire and survives transports
+      // that prune empty/default values.
+      bool null_value = 9;
     }
   }
 

--- a/confidence-resolver/src/lib.rs
+++ b/confidence-resolver/src/lib.rs
@@ -1393,9 +1393,19 @@ impl<'a, H: Host> AccountResolver<'a, H> {
             };
             match &criterion {
                 criterion::Criterion::Attribute(attribute_criterion) => {
-                    let expected_value_type = value::expected_value_type(attribute_criterion);
                     let attribute_value =
                         self.get_attribute_value(&attribute_criterion.attribute_name);
+
+                    // An EqRule against an explicit null value is a null check: it
+                    // matches when the attribute is null or absent. "is not null"
+                    // wraps the reference in Expression.not.
+                    if value::is_null_check(attribute_criterion) {
+                        let is_null =
+                            matches!(attribute_value.kind, None | Some(Kind::NullValue(_)));
+                        return Ok(Some(is_null));
+                    }
+
+                    let expected_value_type = value::expected_value_type(attribute_criterion);
                     let converted =
                         value::convert_to_targeting_value(attribute_value, expected_value_type)?;
                     let wrapped = list_wrapper(&converted);

--- a/confidence-resolver/src/resolver_spec_tests.rs
+++ b/confidence-resolver/src/resolver_spec_tests.rs
@@ -584,6 +584,7 @@ spec_test!(is_null_implicit);
 spec_test!(is_null_non_null_value);
 spec_test!(is_not_null_with_value);
 spec_test!(is_not_null_missing);
+spec_test!(is_not_null_with_dropped_rule);
 
 // NOT any rule
 spec_test!(not_any_no_overlap);

--- a/confidence-resolver/src/resolver_spec_tests.rs
+++ b/confidence-resolver/src/resolver_spec_tests.rs
@@ -584,7 +584,10 @@ spec_test!(is_null_implicit);
 spec_test!(is_null_non_null_value);
 spec_test!(is_not_null_with_value);
 spec_test!(is_not_null_missing);
-spec_test!(is_not_null_with_dropped_rule);
+spec_test!(null_value_is_null_match);
+spec_test!(null_value_is_null_no_match);
+spec_test!(null_value_is_not_null_match);
+spec_test!(null_value_is_not_null_no_match);
 
 // NOT any rule
 spec_test!(not_any_no_overlap);

--- a/confidence-resolver/src/value.rs
+++ b/confidence-resolver/src/value.rs
@@ -416,6 +416,19 @@ pub fn expected_value_type(
     attribute_criterion.expected_value_type()
 }
 
+/// True when the criterion is an EqRule against an explicit null value, i.e. an
+/// "is null" check. "is not null" wraps the reference in Expression.not.
+pub fn is_null_check(attribute_criterion: &targeting::criterion::AttributeCriterion) -> bool {
+    matches!(
+        &attribute_criterion.rule,
+        Some(criterion::attribute_criterion::Rule::EqRule(targeting::EqRule {
+            value: Some(targeting::Value {
+                value: Some(targeting::value::Value::NullValue(_)),
+            }),
+        }))
+    )
+}
+
 trait ExpectedValueType {
     fn expected_value_type(&self) -> Option<&targeting::value::Value>;
 }

--- a/confidence-resolver/test-payloads/resolver-spec/state.json
+++ b/confidence-resolver/test-payloads/resolver-spec/state.json
@@ -1766,6 +1766,32 @@
         }
       ]
     },
+    "flags/dropped-not-null-flag": {
+      "name": "flags/dropped-not-null-flag",
+      "state": "ACTIVE",
+      "clients": ["clients/test-client"],
+      "variants": [
+        { "name": "on", "value": { "enabled": true } }
+      ],
+      "rules": [
+        {
+          "name": "flags/dropped-not-null-flag/rules/rule1",
+          "segment": "segments/dropped-not-null",
+          "enabled": true,
+          "targetingKeySelector": "targeting_key",
+          "assignmentSpec": {
+            "bucketCount": 1000,
+            "assignments": [
+              {
+                "assignmentId": "a1",
+                "variant": { "variant": "on" },
+                "bucketRanges": [{ "lower": 0, "upper": 1000 }]
+              }
+            ]
+          }
+        }
+      ]
+    },
     "flags/not-any-flag": {
       "name": "flags/not-any-flag",
       "state": "ACTIVE",
@@ -2625,6 +2651,20 @@
         "expression": { "not": { "ref": "c1" } }
       }
     },
+    "segments/dropped-not-null": {
+      "name": "segments/dropped-not-null",
+      "state": "OK",
+      "targeting": {
+        "criteria": {
+          "c1": {
+            "attribute": {
+              "attributeName": "country"
+            }
+          }
+        },
+        "expression": { "not": { "ref": "c1" } }
+      }
+    },
     "segments/not-any-rule": {
       "name": "segments/not-any-rule",
       "state": "OK",
@@ -2859,6 +2899,7 @@
     "segments/catch-all": "ALL",
     "segments/is-null": "ALL",
     "segments/is-not-null": "ALL",
+    "segments/dropped-not-null": "ALL",
     "segments/not-any-rule": "ALL",
     "segments/not-all-rule": "ALL",
     "segments/semver-range": "ALL",

--- a/confidence-resolver/test-payloads/resolver-spec/state.json
+++ b/confidence-resolver/test-payloads/resolver-spec/state.json
@@ -1766,8 +1766,8 @@
         }
       ]
     },
-    "flags/dropped-not-null-flag": {
-      "name": "flags/dropped-not-null-flag",
+    "flags/null-value-is-null-flag": {
+      "name": "flags/null-value-is-null-flag",
       "state": "ACTIVE",
       "clients": ["clients/test-client"],
       "variants": [
@@ -1775,8 +1775,34 @@
       ],
       "rules": [
         {
-          "name": "flags/dropped-not-null-flag/rules/rule1",
-          "segment": "segments/dropped-not-null",
+          "name": "flags/null-value-is-null-flag/rules/rule1",
+          "segment": "segments/null-value-is-null",
+          "enabled": true,
+          "targetingKeySelector": "targeting_key",
+          "assignmentSpec": {
+            "bucketCount": 1000,
+            "assignments": [
+              {
+                "assignmentId": "a1",
+                "variant": { "variant": "on" },
+                "bucketRanges": [{ "lower": 0, "upper": 1000 }]
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "flags/null-value-is-not-null-flag": {
+      "name": "flags/null-value-is-not-null-flag",
+      "state": "ACTIVE",
+      "clients": ["clients/test-client"],
+      "variants": [
+        { "name": "on", "value": { "enabled": true } }
+      ],
+      "rules": [
+        {
+          "name": "flags/null-value-is-not-null-flag/rules/rule1",
+          "segment": "segments/null-value-is-not-null",
           "enabled": true,
           "targetingKeySelector": "targeting_key",
           "assignmentSpec": {
@@ -2651,14 +2677,30 @@
         "expression": { "not": { "ref": "c1" } }
       }
     },
-    "segments/dropped-not-null": {
-      "name": "segments/dropped-not-null",
+    "segments/null-value-is-null": {
+      "name": "segments/null-value-is-null",
       "state": "OK",
       "targeting": {
         "criteria": {
           "c1": {
             "attribute": {
-              "attributeName": "country"
+              "attributeName": "country",
+              "eqRule": { "value": { "nullValue": true } }
+            }
+          }
+        },
+        "expression": { "ref": "c1" }
+      }
+    },
+    "segments/null-value-is-not-null": {
+      "name": "segments/null-value-is-not-null",
+      "state": "OK",
+      "targeting": {
+        "criteria": {
+          "c1": {
+            "attribute": {
+              "attributeName": "country",
+              "eqRule": { "value": { "nullValue": true } }
             }
           }
         },
@@ -2899,7 +2941,8 @@
     "segments/catch-all": "ALL",
     "segments/is-null": "ALL",
     "segments/is-not-null": "ALL",
-    "segments/dropped-not-null": "ALL",
+    "segments/null-value-is-null": "ALL",
+    "segments/null-value-is-not-null": "ALL",
     "segments/not-any-rule": "ALL",
     "segments/not-all-rule": "ALL",
     "segments/semver-range": "ALL",

--- a/confidence-resolver/test-payloads/resolver-spec/tests.json
+++ b/confidence-resolver/test-payloads/resolver-spec/tests.json
@@ -2647,10 +2647,39 @@
     }
   },
   {
-    "name": "is_not_null_with_dropped_rule",
+    "name": "null_value_is_null_match",
     "resolveRequest": {
       "flags": [
-        "flags/dropped-not-null-flag"
+        "flags/null-value-is-null-flag"
+      ],
+      "evaluationContext": {
+        "targeting_key": "user1",
+        "country": null
+      },
+      "clientSecret": "test-secret"
+    },
+    "expectedResult": {
+      "general": {
+        "resolvedFlags": [
+          {
+            "flag": "flags/null-value-is-null-flag",
+            "reason": "RESOLVE_REASON_MATCH",
+            "variant": "on",
+            "value": {
+              "enabled": true
+            },
+            "shouldApply": true
+          }
+        ],
+        "expectError": null
+      }
+    }
+  },
+  {
+    "name": "null_value_is_null_no_match",
+    "resolveRequest": {
+      "flags": [
+        "flags/null-value-is-null-flag"
       ],
       "evaluationContext": {
         "targeting_key": "user1",
@@ -2662,13 +2691,67 @@
       "general": {
         "resolvedFlags": [
           {
-            "flag": "flags/dropped-not-null-flag",
+            "flag": "flags/null-value-is-null-flag",
+            "reason": "RESOLVE_REASON_NO_SEGMENT_MATCH",
+            "variant": "",
+            "value": null,
+            "shouldApply": false
+          }
+        ],
+        "expectError": null
+      }
+    }
+  },
+  {
+    "name": "null_value_is_not_null_match",
+    "resolveRequest": {
+      "flags": [
+        "flags/null-value-is-not-null-flag"
+      ],
+      "evaluationContext": {
+        "targeting_key": "user1",
+        "country": "US"
+      },
+      "clientSecret": "test-secret"
+    },
+    "expectedResult": {
+      "general": {
+        "resolvedFlags": [
+          {
+            "flag": "flags/null-value-is-not-null-flag",
             "reason": "RESOLVE_REASON_MATCH",
             "variant": "on",
             "value": {
               "enabled": true
             },
             "shouldApply": true
+          }
+        ],
+        "expectError": null
+      }
+    }
+  },
+  {
+    "name": "null_value_is_not_null_no_match",
+    "resolveRequest": {
+      "flags": [
+        "flags/null-value-is-not-null-flag"
+      ],
+      "evaluationContext": {
+        "targeting_key": "user1",
+        "country": null
+      },
+      "clientSecret": "test-secret"
+    },
+    "expectedResult": {
+      "general": {
+        "resolvedFlags": [
+          {
+            "flag": "flags/null-value-is-not-null-flag",
+            "reason": "RESOLVE_REASON_NO_SEGMENT_MATCH",
+            "variant": "",
+            "value": null,
+            "shouldApply": false
           }
         ],
         "expectError": null

--- a/confidence-resolver/test-payloads/resolver-spec/tests.json
+++ b/confidence-resolver/test-payloads/resolver-spec/tests.json
@@ -2647,6 +2647,35 @@
     }
   },
   {
+    "name": "is_not_null_with_dropped_rule",
+    "resolveRequest": {
+      "flags": [
+        "flags/dropped-not-null-flag"
+      ],
+      "evaluationContext": {
+        "targeting_key": "user1",
+        "country": "US"
+      },
+      "clientSecret": "test-secret"
+    },
+    "expectedResult": {
+      "general": {
+        "resolvedFlags": [
+          {
+            "flag": "flags/dropped-not-null-flag",
+            "reason": "RESOLVE_REASON_MATCH",
+            "variant": "on",
+            "value": {
+              "enabled": true
+            },
+            "shouldApply": true
+          }
+        ],
+        "expectError": null
+      }
+    }
+  },
+  {
     "name": "not_any_no_overlap",
     "resolveRequest": {
       "flags": [


### PR DESCRIPTION
## Summary
Rust mirror of the Java change. Implements **Option C**: an explicit `null_value` member on the `Value` oneof, so "is null" is `eq(null_value)` and "is not null" is `not(eq(null_value))`.

## Why
The previous "empty `EqRule`" encoding is indistinguishable from "unset" across generic proto/JSON transcoding and could be dropped in transit. `null_value` is an explicit, non-empty marker that survives. An `EqRule` against it matches when the attribute is null/absent.

(Also resolves the Rust-specific divergence where the empty-value encoding was mishandled — `is_null` never matched and `is_not_null` matched null.)

## Changes
- `target.proto`: add `bool null_value = 9` to `Value`.
- `lib.rs` + `value.rs`: `eq(null_value)` ⇒ matches when the attribute is null/absent (`is_null_check`).
- Spec + `spec_test!` entries: full is-null / is-not-null coverage via `null_value`.

## Test plan
- [x] `cargo test --lib` — 366 pass, incl. the four `null_value_*` cases
- [ ] Companion: `konfidens/epx-flags-resolver#1675` (Java)