### PR TITLE
ci: improve Docker build performance

### DIFF
--- a/.github/workflows/base-images.yml
+++ b/.github/workflows/base-images.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "docker/**"
+      - "rust-toolchain.toml"
   schedule:
     # Weekly rebuild to pick up security updates from upstream images
     - cron: "0 4 * * 1"
@@ -15,6 +16,32 @@ permissions:
   packages: write
 
 jobs:
+  rust-base:
+    name: Rust base image
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/rust-base.Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/rust-base:latest
+
   java-base:
     name: Java base image
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/base-images.yml
+++ b/.github/workflows/base-images.yml
@@ -1,0 +1,42 @@
+name: Base Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docker/**"
+  schedule:
+    # Weekly rebuild to pick up security updates from upstream images
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  java-base:
+    name: Java base image
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/java-base.Dockerfile
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/${{ github.repository }}/java-base:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # syntax=docker/dockerfile:1
 
+# Pre-baked base images (override with --build-arg for local dev without registry)
+ARG JAVA_BASE_IMAGE=ghcr.io/spotify/confidence-resolver/java-base:latest
+
 # ==============================================================================
 # Base image with Rust toolchain (Alpine - more reliable than Debian)
 # ==============================================================================
@@ -658,14 +661,7 @@ RUN --mount=type=secret,id=crates_io_token \
 # ==============================================================================
 # OpenFeature Provider (Java) - Build and test
 # ==============================================================================
-FROM eclipse-temurin:17-jdk AS openfeature-provider-java-base
-
-# Install Maven and protobuf (Debian-based for glibc compatibility)
-RUN apt-get update && apt-get install -y \
-    maven \
-    protobuf-compiler \
-    make \
-  && rm -rf /var/lib/apt/lists/*
+FROM ${JAVA_BASE_IMAGE} AS openfeature-provider-java-base
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,13 @@
 # syntax=docker/dockerfile:1
 
 # Pre-baked base images (override with --build-arg for local dev without registry)
+ARG RUST_BASE_IMAGE=ghcr.io/spotify/confidence-resolver/rust-base:latest
 ARG JAVA_BASE_IMAGE=ghcr.io/spotify/confidence-resolver/java-base:latest
 
 # ==============================================================================
 # Base image with Rust toolchain (Alpine - more reliable than Debian)
 # ==============================================================================
-FROM alpine:3.22 AS rust-base
-
-# Install system dependencies
-# - protoc/protobuf-dev: Required for prost-build (proto compilation in build.rs)
-# - musl-dev: Required for linking Rust binaries on Alpine
-RUN apk add --no-cache \
-    protobuf-dev \
-    protoc \
-    musl-dev \
-    make \
-    gcc \
-    curl \
-    ca-certificates
-
-# Install rustup into system-wide dirs so later stages can cache/copy them
-ENV CARGO_HOME=/usr/local/cargo \
-    RUSTUP_HOME=/usr/local/rustup \
-    PATH=/usr/local/cargo/bin:$PATH
-
-# Install rustup with no default toolchain; the toolchain file will drive installs
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
-    sh -s -- -y --profile minimal --default-toolchain none
-
-WORKDIR /workspace
-
-# Copy rust-toolchain.toml and let rustup configure everything automatically
-COPY rust-toolchain.toml ./
-
-# Install toolchain from rust-toolchain.toml (components + targets)
-RUN rustup show
+FROM ${RUST_BASE_IMAGE} AS rust-base
 
 # ==============================================================================
 # Dependencies layer - cached separately from source code

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ js-bench: js-build
 # Build pre-baked base images locally (for bootstrapping or offline dev)
 .PHONY: base-images
 base-images:
+	@docker build -f docker/rust-base.Dockerfile -t ghcr.io/spotify/confidence-resolver/rust-base:latest .
 	@docker build -f docker/java-base.Dockerfile -t ghcr.io/spotify/confidence-resolver/java-base:latest .
 	@echo "✅ Base images built"
 

--- a/Makefile
+++ b/Makefile
@@ -101,4 +101,10 @@ js-bench: js-build
 	docker compose down --remove-orphans --volumes; \
 	exit $$status
 
+# Build pre-baked base images locally (for bootstrapping or offline dev)
+.PHONY: base-images
+base-images:
+	@docker build -f docker/java-base.Dockerfile -t ghcr.io/spotify/confidence-resolver/java-base:latest .
+	@echo "✅ Base images built"
+
 .DEFAULT_GOAL := all

--- a/docker/java-base.Dockerfile
+++ b/docker/java-base.Dockerfile
@@ -1,0 +1,9 @@
+# Pre-baked Java base image with maven + protobuf-compiler + make.
+# Built separately so the main Dockerfile skips the ~37s apt-get install.
+FROM eclipse-temurin:17-jdk
+
+RUN apt-get update && apt-get install -y \
+    maven \
+    protobuf-compiler \
+    make \
+  && rm -rf /var/lib/apt/lists/*

--- a/docker/rust-base.Dockerfile
+++ b/docker/rust-base.Dockerfile
@@ -1,0 +1,25 @@
+# Pre-baked Rust base image with system deps + toolchain from rust-toolchain.toml.
+# Built separately so the main Dockerfile skips the ~21s install on cold cache.
+FROM alpine:3.22
+
+RUN apk add --no-cache \
+    protobuf-dev \
+    protoc \
+    musl-dev \
+    make \
+    gcc \
+    curl \
+    ca-certificates
+
+ENV CARGO_HOME=/usr/local/cargo \
+    RUSTUP_HOME=/usr/local/rustup \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+    sh -s -- -y --profile minimal --default-toolchain none
+
+WORKDIR /workspace
+
+COPY rust-toolchain.toml ./
+
+RUN rustup show


### PR DESCRIPTION
## Summary
- Pre-bake the Java base image (eclipse-temurin + maven/protoc/make) and publish to ghcr.io, eliminating ~37s apt-get install on cold-cache builds
- Add `base-images.yml` workflow to build/push weekly + on changes to `docker/`
- Add `make base-images` for local bootstrap

> **Bootstrap**: after merge, trigger the `Base Images` workflow manually via `workflow_dispatch` to seed the ghcr.io image. After that, all builds pull it automatically.

More CI perf improvements to follow in this PR.

## Test plan
- [ ] Verified `make base-images` builds the image locally
- [ ] Verified `docker build --target openfeature-provider-java.build .` works with pre-baked image
- [ ] Trigger `base-images` workflow manually after merge to bootstrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)