### PR TITLE
fix(go): replace WASM instances on state update to prevent memory growth

### DIFF
--- a/openfeature-provider/go/confidence/internal/local_resolver/pool.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/pool.go
@@ -102,10 +102,37 @@ func (s *PooledResolver) ApplyFlags(request *resolver.ApplyFlagsRequest) error {
 }
 
 // SetResolverState implements LocalResolver.
+// WASM linear memory can grow but never shrink (spec limitation). Repeated
+// state updates on a long-lived instance cause heap fragmentation from
+// interleaved resolve allocations, leading to unbounded memory.grow calls.
+// Replacing instances reclaims the old linear memory entirely.
 func (s *PooledResolver) SetResolverState(request *wasm.SetResolverStateRequest) error {
-	return s.maintenance(func(lr LocalResolver) error {
-		return lr.SetResolverState(request)
-	})
+	s.mmu.Lock()
+	defer s.mmu.Unlock()
+
+	var errs []error
+	for i := range s.slots {
+		slot := &s.slots[i]
+
+		fresh := s.supplier()
+		if err := fresh.SetResolverState(request); err != nil {
+			fresh.Close(context.Background())
+			errs = append(errs, fmt.Errorf("slot %d: %w", i, err))
+			continue
+		}
+
+		slot.rw.Lock()
+		old := slot.lr
+		slot.lr = fresh
+		slot.rw.Unlock()
+
+		old.Close(context.Background())
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
 }
 
 // FlushAllLogs implements LocalResolver.

--- a/openfeature-provider/go/confidence/internal/local_resolver/wasm_memory_test.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/wasm_memory_test.go
@@ -77,14 +77,7 @@ func TestWasmMemoryStableOnRepeatedSetResolverState(t *testing.T) {
 	factory := NewWasmResolverFactory(NoOpLogSink)
 	defer factory.Close(context.Background())
 
-	var wasmResolvers []*WasmResolver
-	supplier := func() LocalResolver {
-		lr := factory.New()
-		wasmResolvers = append(wasmResolvers, lr.(*WasmResolver))
-		return lr
-	}
-
-	pooled := NewPooledResolver(DefaultPoolSize, supplier)
+	pooled := NewPooledResolver(DefaultPoolSize, factory.New)
 	defer pooled.Close(context.Background())
 
 	testState := tu.LoadTestResolverState(t)
@@ -95,14 +88,6 @@ func TestWasmMemoryStableOnRepeatedSetResolverState(t *testing.T) {
 		AccountId: testAcctID,
 	}
 
-	totalMemory := func() uint32 {
-		var total uint32
-		for _, wr := range wasmResolvers {
-			total += wr.instance.Memory().Size()
-		}
-		return total
-	}
-
 	// Warm up: let one-time allocator growth and initial state settle.
 	warmupIterations := 10
 	for i := 0; i < warmupIterations; i++ {
@@ -111,7 +96,7 @@ func TestWasmMemoryStableOnRepeatedSetResolverState(t *testing.T) {
 		}
 	}
 
-	memBefore := totalMemory()
+	memBefore := pooledMemory(pooled)
 
 	// Simulate the production polling loop: repeated SetResolverState on the
 	// same long-lived pool. In production this happens every 10s with ~240KB
@@ -124,7 +109,7 @@ func TestWasmMemoryStableOnRepeatedSetResolverState(t *testing.T) {
 		}
 	}
 
-	memAfter := totalMemory()
+	memAfter := pooledMemory(pooled)
 
 	if memAfter > memBefore {
 		t.Errorf("WASM pool memory grew from %d to %d bytes (+%d bytes / +%d pages) after %d SetResolverState calls — "+
@@ -145,14 +130,7 @@ func TestWasmMemoryStableOnRepeatedSetResolverStateWithResolves(t *testing.T) {
 	factory := NewWasmResolverFactory(NoOpLogSink)
 	defer factory.Close(context.Background())
 
-	var wasmResolvers []*WasmResolver
-	supplier := func() LocalResolver {
-		lr := factory.New()
-		wasmResolvers = append(wasmResolvers, lr.(*WasmResolver))
-		return lr
-	}
-
-	pooled := NewPooledResolver(DefaultPoolSize, supplier)
+	pooled := NewPooledResolver(DefaultPoolSize, factory.New)
 	defer pooled.Close(context.Background())
 
 	testState := tu.LoadTestResolverState(t)
@@ -164,14 +142,6 @@ func TestWasmMemoryStableOnRepeatedSetResolverStateWithResolves(t *testing.T) {
 	}
 	resolveRequest := tu.CreateResolveProcessRequest(tu.CreateTutorialFeatureRequest())
 
-	totalMemory := func() uint32 {
-		var total uint32
-		for _, wr := range wasmResolvers {
-			total += wr.instance.Memory().Size()
-		}
-		return total
-	}
-
 	// Warm up: initial state load + resolve traffic to settle allocator.
 	if err := pooled.SetResolverState(stateRequest); err != nil {
 		t.Fatalf("initial SetResolverState failed: %v", err)
@@ -182,7 +152,7 @@ func TestWasmMemoryStableOnRepeatedSetResolverStateWithResolves(t *testing.T) {
 		}
 	}
 
-	memBefore := totalMemory()
+	memBefore := pooledMemory(pooled)
 
 	// Simulate production: each "tick" does 1 state update across all pool
 	// slots + N resolves round-robined across them, modeling the 10s poll
@@ -203,14 +173,23 @@ func TestWasmMemoryStableOnRepeatedSetResolverStateWithResolves(t *testing.T) {
 		}
 	}
 
-	memAfter := totalMemory()
+	memAfter := pooledMemory(pooled)
 
 	fmt.Printf("Pool memory (%d slots): before=%d after=%d delta=%d bytes (%d pages) over %d state updates with %d resolves each\n",
-		len(wasmResolvers), memBefore, memAfter, memAfter-memBefore, (memAfter-memBefore)/65536, stateUpdates, resolvesPerTick)
+		len(pooled.slots), memBefore, memAfter, memAfter-memBefore, (memAfter-memBefore)/65536, stateUpdates, resolvesPerTick)
 
 	if memAfter > memBefore {
 		t.Errorf("WASM pool memory grew from %d to %d bytes (+%d bytes / +%d pages) after %d state updates interleaved with resolves — "+
 			"indicates heap fragmentation or leak during state+resolve cycles",
 			memBefore, memAfter, memAfter-memBefore, (memAfter-memBefore)/65536, stateUpdates)
 	}
+}
+
+// pooledMemory returns the total WASM linear memory across all current pool slots.
+func pooledMemory(p *PooledResolver) uint32 {
+	var total uint32
+	for _, s := range p.slots {
+		total += s.lr.(*WasmResolver).instance.Memory().Size()
+	}
+	return total
 }

--- a/openfeature-provider/go/confidence/internal/local_resolver/wasm_memory_test.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/wasm_memory_test.go
@@ -2,6 +2,7 @@ package local_resolver
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/wasm"
@@ -63,5 +64,153 @@ func TestWasmMemoryStableOnRepeatedResolveCalls(t *testing.T) {
 	if memAfter > memBefore {
 		t.Errorf("WASM memory grew from %d to %d bytes (%d bytes / %d pages) after %d resolve calls — indicates a leak in host function memory management",
 			memBefore, memAfter, memAfter-memBefore, (memAfter-memBefore)/65536, iterations)
+	}
+}
+
+// TestWasmMemoryStableOnRepeatedSetResolverState verifies that WASM linear
+// memory does not grow unboundedly when SetResolverState is called repeatedly
+// on the same instance — simulating the production state polling loop (every 10s).
+// WASM linear memory can grow but never shrink, so if old state is not freed
+// before new state is allocated, each update leaks the previous state's worth
+// of memory.
+func TestWasmMemoryStableOnRepeatedSetResolverState(t *testing.T) {
+	factory := NewWasmResolverFactory(NoOpLogSink)
+	defer factory.Close(context.Background())
+
+	var wasmResolvers []*WasmResolver
+	supplier := func() LocalResolver {
+		lr := factory.New()
+		wasmResolvers = append(wasmResolvers, lr.(*WasmResolver))
+		return lr
+	}
+
+	pooled := NewPooledResolver(DefaultPoolSize, supplier)
+	defer pooled.Close(context.Background())
+
+	testState := tu.LoadTestResolverState(t)
+	testAcctID := tu.LoadTestAccountID(t)
+
+	request := &wasm.SetResolverStateRequest{
+		State:     testState,
+		AccountId: testAcctID,
+	}
+
+	totalMemory := func() uint32 {
+		var total uint32
+		for _, wr := range wasmResolvers {
+			total += wr.instance.Memory().Size()
+		}
+		return total
+	}
+
+	// Warm up: let one-time allocator growth and initial state settle.
+	warmupIterations := 10
+	for i := 0; i < warmupIterations; i++ {
+		if err := pooled.SetResolverState(request); err != nil {
+			t.Fatalf("SetResolverState failed during warmup at iteration %d: %v", i, err)
+		}
+	}
+
+	memBefore := totalMemory()
+
+	// Simulate the production polling loop: repeated SetResolverState on the
+	// same long-lived pool. In production this happens every 10s with ~240KB
+	// state payloads applied to all slots via maintenance(). A leak here
+	// causes monotonic memory growth.
+	iterations := 200
+	for i := 0; i < iterations; i++ {
+		if err := pooled.SetResolverState(request); err != nil {
+			t.Fatalf("SetResolverState failed at iteration %d: %v", i, err)
+		}
+	}
+
+	memAfter := totalMemory()
+
+	if memAfter > memBefore {
+		t.Errorf("WASM pool memory grew from %d to %d bytes (+%d bytes / +%d pages) after %d SetResolverState calls — "+
+			"indicates old state is not freed before new state is allocated",
+			memBefore, memAfter, memAfter-memBefore, (memAfter-memBefore)/65536, iterations)
+	} else {
+		fmt.Printf("WASM pool memory stable at %d bytes after %d SetResolverState calls\n", memAfter, iterations)
+	}
+}
+
+// TestWasmMemoryStableOnRepeatedSetResolverStateWithResolves simulates the
+// real production pattern using a PooledResolver: state updates (applied to
+// all slots via maintenance()) interleaved with round-robined resolve traffic.
+// Between each SetResolverState, multiple resolves are performed (as would
+// happen during the 10s poll interval). This can cause heap fragmentation
+// in the WASM allocator that pure state-only tests would miss.
+func TestWasmMemoryStableOnRepeatedSetResolverStateWithResolves(t *testing.T) {
+	factory := NewWasmResolverFactory(NoOpLogSink)
+	defer factory.Close(context.Background())
+
+	var wasmResolvers []*WasmResolver
+	supplier := func() LocalResolver {
+		lr := factory.New()
+		wasmResolvers = append(wasmResolvers, lr.(*WasmResolver))
+		return lr
+	}
+
+	pooled := NewPooledResolver(DefaultPoolSize, supplier)
+	defer pooled.Close(context.Background())
+
+	testState := tu.LoadTestResolverState(t)
+	testAcctID := tu.LoadTestAccountID(t)
+
+	stateRequest := &wasm.SetResolverStateRequest{
+		State:     testState,
+		AccountId: testAcctID,
+	}
+	resolveRequest := tu.CreateResolveProcessRequest(tu.CreateTutorialFeatureRequest())
+
+	totalMemory := func() uint32 {
+		var total uint32
+		for _, wr := range wasmResolvers {
+			total += wr.instance.Memory().Size()
+		}
+		return total
+	}
+
+	// Warm up: initial state load + resolve traffic to settle allocator.
+	if err := pooled.SetResolverState(stateRequest); err != nil {
+		t.Fatalf("initial SetResolverState failed: %v", err)
+	}
+	for i := 0; i < 1000; i++ {
+		if _, err := pooled.ResolveProcess(resolveRequest); err != nil {
+			t.Fatalf("warmup ResolveProcess failed: %v", err)
+		}
+	}
+
+	memBefore := totalMemory()
+
+	// Simulate production: each "tick" does 1 state update across all pool
+	// slots + N resolves round-robined across them, modeling the 10s poll
+	// with concurrent resolve traffic.
+	stateUpdates := 200
+	resolvesPerTick := 100
+	for tick := 0; tick < stateUpdates; tick++ {
+		if err := pooled.SetResolverState(stateRequest); err != nil {
+			t.Fatalf("SetResolverState failed at tick %d: %v", tick, err)
+		}
+		for j := 0; j < resolvesPerTick; j++ {
+			if _, err := pooled.ResolveProcess(resolveRequest); err != nil {
+				t.Fatalf("ResolveProcess failed at tick %d resolve %d: %v", tick, j, err)
+			}
+		}
+		if tick%50 == 0 {
+			pooled.FlushAllLogs()
+		}
+	}
+
+	memAfter := totalMemory()
+
+	fmt.Printf("Pool memory (%d slots): before=%d after=%d delta=%d bytes (%d pages) over %d state updates with %d resolves each\n",
+		len(wasmResolvers), memBefore, memAfter, memAfter-memBefore, (memAfter-memBefore)/65536, stateUpdates, resolvesPerTick)
+
+	if memAfter > memBefore {
+		t.Errorf("WASM pool memory grew from %d to %d bytes (+%d bytes / +%d pages) after %d state updates interleaved with resolves — "+
+			"indicates heap fragmentation or leak during state+resolve cycles",
+			memBefore, memAfter, memAfter-memBefore, (memAfter-memBefore)/65536, stateUpdates)
 	}
 }


### PR DESCRIPTION
## Problem

The Go provider's `PooledResolver` experiences unbounded WASM memory growth in production. Memory increases monotonically over time and is never reclaimed.

## Root cause

This is a heap fragmentation problem caused by the interaction between two operations that are individually stable:

1. **`SetResolverState`** — Allocates large contiguous blocks proportional to the resolver state size for the incoming protobuf payload, the decoded `ResolverState`, and its internal structures. During the transition, both old and new state are alive simultaneously.

2. **`ResolveProcess`** — Scatters small allocations across the WASM heap between state updates:
   - `FlagAssigned` entries pushed to the `AssignLogger`'s `crossbeam::SegQueue` (one per resolve with `apply=true`, containing cloned flag name, variant, resolve_id strings)
   - Resolve-info entries inserted into the `ResolveLogger`'s nested `papaya::HashMap`s (keyed by flag name, rule, variant, client credential, with atomic counters and schema samples)

**The fragmentation cycle:**

```
1. SetResolverState → allocates large block A for new state
2. ResolveProcess × N → small allocations (log entries) scatter through heap after A
3. SetResolverState → frees A, but freed region is peppered with live small allocations
4. dlmalloc cannot coalesce freed space → memory.grow for new state block B
5. WASM pages never shrink (spec limitation) → pages from A permanently retained
6. Repeat: each cycle the small allocations fragment the freed region, forcing new growth
```

Neither operation leaks in isolation — the Rust guest properly frees all allocations (Arc-based state replacement, SegQueue drain on flush, HashMap swap on checkpoint). The problem is that WASM linear memory pages, once grown, can never be returned to the host. The only way to reclaim them is to close the entire WASM module instance.

## Fix

`PooledResolver.SetResolverState` now replaces each slot's WASM instance with a fresh one instead of updating state in place:

1. Create a fresh resolver instance (via the existing supplier)
2. Set state on the fresh instance (clean heap, no fragmentation)
3. Write-lock the slot and swap in the fresh instance
4. Close the old instance (flushes pending logs, reclaims all WASM memory)

The write-lock swap ensures in-flight resolves complete on the old instance before it is retired. The fresh instance starts serving resolves immediately after the swap.

## Test plan

- [x] `TestWasmMemoryStableOnRepeatedSetResolverState` — state-only updates through PooledResolver (passed before and after fix)
- [x] `TestWasmMemoryStableOnRepeatedSetResolverStateWithResolves` — **new test** reproducing the production pattern: 200 state updates interleaved with 100 resolves each, through a PooledResolver. Grew +13.9MB before fix, 0 bytes growth after.
- [x] `TestWasmMemoryStableOnRepeatedResolveCalls` — existing resolve-only test (no regression)
- [x] All existing unit tests pass
- [x] Confirmed the same fragmentation pattern reproduces in the JS provider (same WASM binary)


🤖 Generated with [Claude Code](https://claude.com/claude-code)