### PR TITLE
feat(js): support encrypted CDN resolver state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare secrets
-        run: echo "${{ secrets.CONFIDENCE_CLIENT_SECRET }}" > /tmp/confidence_client_secret.txt
+        run: |
+          echo "${{ secrets.CONFIDENCE_CLIENT_SECRET }}" > /tmp/confidence_client_secret.txt
+          echo "${{ secrets.CONFIDENCE_CLIENT_ENCRYPTION_KEY }}" > /tmp/confidence_client_encryption_key.txt
 
       - name: Build and test everything (PR)
         if: github.event_name != 'push'
@@ -42,6 +44,7 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cache:main
           secret-files: |
             confidence_client_secret=/tmp/confidence_client_secret.txt
+            confidence_client_encryption_key=/tmp/confidence_client_encryption_key.txt
 
       - name: Build and test everything (Push - updates cache)
         if: github.event_name == 'push'
@@ -54,3 +57,4 @@ jobs:
           cache-to: type=registry,ref=ghcr.io/${{ github.repository }}/cache:main,mode=max
           secret-files: |
             confidence_client_secret=/tmp/confidence_client_secret.txt
+            confidence_client_encryption_key=/tmp/confidence_client_encryption_key.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -316,6 +316,8 @@ FROM openfeature-provider-js-base AS openfeature-provider-js.test
 
 # Copy files needed for testing
 COPY wasm/resolver_state.pb ../../../wasm/resolver_state.pb
+COPY data/resolver_state_encrypted.pb ../../../data/resolver_state_encrypted.pb
+COPY data/encryption_key_test.hex ../../../data/encryption_key_test.hex
 COPY openfeature-provider/js/prettier.config.cjs ./
 COPY openfeature-provider/js/.prettierignore ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -332,7 +332,9 @@ FROM openfeature-provider-js.test AS openfeature-provider-js.test_e2e
 
 # Run e2e tests with secrets mounted
 RUN --mount=type=secret,id=confidence_client_secret \
+    --mount=type=secret,id=confidence_client_encryption_key \
     CONFIDENCE_CLIENT_SECRET=$(cat /run/secrets/confidence_client_secret) \
+    CONFIDENCE_CLIENT_ENCRYPTION_KEY=$(cat /run/secrets/confidence_client_encryption_key) \
     make test-e2e
 
 # ==============================================================================

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.e2e.test.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.e2e.test.ts
@@ -112,19 +112,26 @@ describe('ConfidenceServerProvider Encrypted E2E tests', () => {
   it('should resolve a boolean via encrypted state', async () => {
     const client = OpenFeature.getClient('encrypted-e2e');
 
-    expect(await client.getBooleanValue('web-sdk-e2e-flag.bool', true, { targetingKey: 'test-a', sticky: false })).toBeFalsy();
+    expect(
+      await client.getBooleanValue('web-sdk-e2e-flag.bool', true, { targetingKey: 'test-a', sticky: false }),
+    ).toBeFalsy();
   });
 
   it('should resolve a string via encrypted state', async () => {
     const client = OpenFeature.getClient('encrypted-e2e');
 
-    expect(await client.getStringValue('web-sdk-e2e-flag.str', 'default', { targetingKey: 'test-a', sticky: false })).toEqual('control');
+    expect(
+      await client.getStringValue('web-sdk-e2e-flag.str', 'default', { targetingKey: 'test-a', sticky: false }),
+    ).toEqual('control');
   });
 
   it('should resolve with details via encrypted state', async () => {
     const client = OpenFeature.getClient('encrypted-e2e');
 
-    const details = await client.getNumberDetails('web-sdk-e2e-flag.obj.double', 1, { targetingKey: 'test-a', sticky: false });
+    const details = await client.getNumberDetails('web-sdk-e2e-flag.obj.double', 1, {
+      targetingKey: 'test-a',
+      sticky: false,
+    });
     expect(details.value).toEqual(3.6);
     expect(details.reason).toEqual('MATCH');
     expect(details.variant).toEqual('flags/web-sdk-e2e-flag/variants/control');

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.e2e.test.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.e2e.test.ts
@@ -6,49 +6,51 @@ import { WasmResolver } from './WasmResolver';
 
 const moduleBytes = readFileSync(__dirname + '/../../../wasm/confidence_resolver.wasm');
 const module = new WebAssembly.Module(moduleBytes);
-const resolver = new WasmResolver(module);
-const confidenceProvider = new ConfidenceServerProviderLocal(resolver, {
-  flagClientSecret: process.env.CONFIDENCE_CLIENT_SECRET!,
-  materializationStore: 'CONFIDENCE_REMOTE_STORE',
-});
 
-describe('ConfidenceServerProvider E2E tests', () => {
+describe.each([
+  { name: 'unencrypted', encryptionKey: undefined },
+  { name: 'encrypted', encryptionKey: process.env.CONFIDENCE_CLIENT_ENCRYPTION_KEY },
+])('ConfidenceServerProvider E2E ($name)', ({ name, encryptionKey }) => {
+  const resolver = new WasmResolver(module);
+  const provider = new ConfidenceServerProviderLocal(resolver, {
+    flagClientSecret: process.env.CONFIDENCE_CLIENT_SECRET!,
+    encryptionKey,
+  });
+
   beforeAll(async () => {
-    await OpenFeature.setProviderAndWait(confidenceProvider);
-    OpenFeature.setContext({
-      targetingKey: 'test-a', // control
-      sticky: false,
-    });
+    await OpenFeature.setProviderAndWait(`e2e-${name}`, provider);
   });
 
   afterAll(() => OpenFeature.close());
 
-  it('should resolve a boolean e2e', async () => {
-    const client = OpenFeature.getClient();
+  const ctx = { targetingKey: 'test-a', sticky: false };
 
-    expect(await client.getBooleanValue('web-sdk-e2e-flag.bool', true)).toBeFalsy();
+  it('should resolve a boolean e2e', async () => {
+    const client = OpenFeature.getClient(`e2e-${name}`);
+
+    expect(await client.getBooleanValue('web-sdk-e2e-flag.bool', true, ctx)).toBeFalsy();
   });
 
   it('should resolve an int', async () => {
-    const client = OpenFeature.getClient();
+    const client = OpenFeature.getClient(`e2e-${name}`);
 
-    expect(await client.getNumberValue('web-sdk-e2e-flag.int', 10)).toEqual(3);
+    expect(await client.getNumberValue('web-sdk-e2e-flag.int', 10, ctx)).toEqual(3);
   });
 
   it('should resolve a double', async () => {
-    const client = OpenFeature.getClient();
+    const client = OpenFeature.getClient(`e2e-${name}`);
 
-    expect(await client.getNumberValue('web-sdk-e2e-flag.double', 10)).toEqual(3.5);
+    expect(await client.getNumberValue('web-sdk-e2e-flag.double', 10, ctx)).toEqual(3.5);
   });
 
   it('should resolve a string', async () => {
-    const client = OpenFeature.getClient();
+    const client = OpenFeature.getClient(`e2e-${name}`);
 
-    expect(await client.getStringValue('web-sdk-e2e-flag.str', 'default')).toEqual('control');
+    expect(await client.getStringValue('web-sdk-e2e-flag.str', 'default', ctx)).toEqual('control');
   });
 
   it('should resolve a struct', async () => {
-    const client = OpenFeature.getClient();
+    const client = OpenFeature.getClient(`e2e-${name}`);
     const expectedObject = {
       int: 4,
       str: 'obj control',
@@ -57,17 +59,17 @@ describe('ConfidenceServerProvider E2E tests', () => {
       ['obj-obj']: {},
     };
 
-    expect(await client.getObjectValue('web-sdk-e2e-flag.obj', {})).toEqual(expectedObject);
+    expect(await client.getObjectValue('web-sdk-e2e-flag.obj', {}, ctx)).toEqual(expectedObject);
   });
 
   it('should resolve a sub value from a struct', async () => {
-    const client = OpenFeature.getClient();
+    const client = OpenFeature.getClient(`e2e-${name}`);
 
-    expect(await client.getBooleanValue('web-sdk-e2e-flag.obj.bool', true)).toBeFalsy();
+    expect(await client.getBooleanValue('web-sdk-e2e-flag.obj.bool', true, ctx)).toBeFalsy();
   });
 
   it('should resolve a sub value from a struct with details with resolve token for client side apply call', async () => {
-    const client = OpenFeature.getClient();
+    const client = OpenFeature.getClient(`e2e-${name}`);
     const expectedObject = {
       flagKey: 'web-sdk-e2e-flag.obj.double',
       reason: 'MATCH',
@@ -77,11 +79,29 @@ describe('ConfidenceServerProvider E2E tests', () => {
       shouldApply: true,
     };
 
-    expect(await client.getNumberDetails('web-sdk-e2e-flag.obj.double', 1)).toEqual(expectedObject);
+    expect(await client.getNumberDetails('web-sdk-e2e-flag.obj.double', 1, ctx)).toEqual(expectedObject);
+  });
+});
+
+describe('ConfidenceServerProvider E2E (sticky)', () => {
+  const resolver = new WasmResolver(module);
+  const provider = new ConfidenceServerProviderLocal(resolver, {
+    flagClientSecret: process.env.CONFIDENCE_CLIENT_SECRET!,
+    materializationStore: 'CONFIDENCE_REMOTE_STORE',
   });
 
+  beforeAll(async () => {
+    await OpenFeature.setProviderAndWait('e2e-sticky', provider);
+    OpenFeature.setContext({
+      targetingKey: 'test-a',
+      sticky: false,
+    });
+  });
+
+  afterAll(() => OpenFeature.close());
+
   it('should resolve a flag with a sticky resolve', async () => {
-    const client = OpenFeature.getClient();
+    const client = OpenFeature.getClient('e2e-sticky');
     const result = await client.getNumberDetails('web-sdk-e2e-flag.double', -1, {
       targetingKey: 'test-3',
       sticky: true,
@@ -95,56 +115,3 @@ describe('ConfidenceServerProvider E2E tests', () => {
     expect(result.reason).toBe('MATCH');
   });
 });
-
-describe('ConfidenceServerProvider Encrypted E2E tests', () => {
-  const encryptedResolver = new WasmResolver(module);
-  const encryptedProvider = new ConfidenceServerProviderLocal(encryptedResolver, {
-    flagClientSecret: process.env.CONFIDENCE_CLIENT_SECRET!,
-    encryptionKey: process.env.CONFIDENCE_CLIENT_ENCRYPTION_KEY,
-  });
-
-  beforeAll(async () => {
-    await OpenFeature.setProviderAndWait('encrypted-e2e', encryptedProvider);
-  });
-
-  afterAll(() => OpenFeature.close());
-
-  it('should resolve a boolean via encrypted state', async () => {
-    const client = OpenFeature.getClient('encrypted-e2e');
-
-    expect(
-      await client.getBooleanValue('web-sdk-e2e-flag.bool', true, { targetingKey: 'test-a', sticky: false }),
-    ).toBeFalsy();
-  });
-
-  it('should resolve a string via encrypted state', async () => {
-    const client = OpenFeature.getClient('encrypted-e2e');
-
-    expect(
-      await client.getStringValue('web-sdk-e2e-flag.str', 'default', { targetingKey: 'test-a', sticky: false }),
-    ).toEqual('control');
-  });
-
-  it('should resolve with details via encrypted state', async () => {
-    const client = OpenFeature.getClient('encrypted-e2e');
-
-    const details = await client.getNumberDetails('web-sdk-e2e-flag.obj.double', 1, {
-      targetingKey: 'test-a',
-      sticky: false,
-    });
-    expect(details.value).toEqual(3.6);
-    expect(details.reason).toEqual('MATCH');
-    expect(details.variant).toEqual('flags/web-sdk-e2e-flag/variants/control');
-  });
-});
-
-function requireEnv<const N extends string[]>(...names: N): Record<N[number], string> {
-  return names.reduce((acc, name) => {
-    const value = process.env[name];
-    if (!value) throw new Error(`Missing environment variable ${name}`);
-    return {
-      ...acc,
-      [name]: value,
-    };
-  }, {}) as Record<N[number], string>;
-}

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.e2e.test.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.e2e.test.ts
@@ -96,6 +96,41 @@ describe('ConfidenceServerProvider E2E tests', () => {
   });
 });
 
+describe('ConfidenceServerProvider Encrypted E2E tests', () => {
+  const encryptedResolver = new WasmResolver(module);
+  const encryptedProvider = new ConfidenceServerProviderLocal(encryptedResolver, {
+    flagClientSecret: process.env.CONFIDENCE_CLIENT_SECRET!,
+    encryptionKey: process.env.CONFIDENCE_CLIENT_ENCRYPTION_KEY,
+  });
+
+  beforeAll(async () => {
+    await OpenFeature.setProviderAndWait('encrypted-e2e', encryptedProvider);
+  });
+
+  afterAll(() => OpenFeature.close());
+
+  it('should resolve a boolean via encrypted state', async () => {
+    const client = OpenFeature.getClient('encrypted-e2e');
+
+    expect(await client.getBooleanValue('web-sdk-e2e-flag.bool', true, { targetingKey: 'test-a', sticky: false })).toBeFalsy();
+  });
+
+  it('should resolve a string via encrypted state', async () => {
+    const client = OpenFeature.getClient('encrypted-e2e');
+
+    expect(await client.getStringValue('web-sdk-e2e-flag.str', 'default', { targetingKey: 'test-a', sticky: false })).toEqual('control');
+  });
+
+  it('should resolve with details via encrypted state', async () => {
+    const client = OpenFeature.getClient('encrypted-e2e');
+
+    const details = await client.getNumberDetails('web-sdk-e2e-flag.obj.double', 1, { targetingKey: 'test-a', sticky: false });
+    expect(details.value).toEqual(3.6);
+    expect(details.reason).toEqual('MATCH');
+    expect(details.variant).toEqual('flags/web-sdk-e2e-flag/variants/control');
+  });
+});
+
 function requireEnv<const N extends string[]>(...names: N): Record<N[number], string> {
   return names.reduce((acc, name) => {
     const value = process.env[name];

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.test.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.test.ts
@@ -21,6 +21,7 @@ const mockedWasmResolver: MockedObject<LocalResolver> = {
   resolveProcess: vi.fn(),
   registerResolve: vi.fn(),
   setResolverState: vi.fn(),
+  setEncryptedResolverState: vi.fn(),
   flushLogs: vi.fn().mockReturnValue(new Uint8Array(100)),
   flushAssigned: vi.fn().mockReturnValue(new Uint8Array(50)),
   applyFlags: vi.fn(),

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
@@ -144,7 +144,12 @@ export class ConfidenceServerProviderLocal implements Provider {
   }
 
   async initialize(context?: EvaluationContext): Promise<void> {
-    // TODO validate options and switch to fatal.
+    if (!this.options.encryptionKey) {
+      logger.warn(
+        'No encryptionKey provided. Falling back to unencrypted state. ' +
+          'An encryption key will be required in an upcoming version.',
+      );
+    }
     const signal = this.main.signal;
     const initialUpdateSignal = AbortSignal.any([
       signal,
@@ -296,9 +301,10 @@ export class ConfidenceServerProviderLocal implements Provider {
   }
 
   async updateState(signal?: AbortSignal): Promise<void> {
-    // Build CDN URL using SHA256 hash of client secret
     const hashHex = await sha256Hex(this.options.flagClientSecret);
-    const cdnUrl = `https://confidence-resolver-state-cdn.spotifycdn.com/${hashHex}`;
+    const { encryptionKey } = this.options;
+    const cdnPath = encryptionKey ? `${hashHex}.enc` : hashHex;
+    const cdnUrl = `https://confidence-resolver-state-cdn.spotifycdn.com/${cdnPath}`;
 
     const headers = new Headers();
     if (this.stateEtag) {
@@ -306,7 +312,6 @@ export class ConfidenceServerProviderLocal implements Provider {
     }
     const resp = await this.fetch(cdnUrl, { headers, signal });
     if (resp.status === 304) {
-      // not changed
       return;
     }
     if (!resp.ok) {
@@ -315,32 +320,19 @@ export class ConfidenceServerProviderLocal implements Provider {
     this.stateEtag = resp.headers.get('etag');
 
     const bytes = new Uint8Array(await resp.arrayBuffer());
-    let encrypted = resp.headers.get('x-amz-meta-encrypted') === 'true';
+    const sdk = { id: SdkId.SDK_ID_JS_LOCAL_SERVER_PROVIDER, version: VERSION };
 
-    if (!encrypted) {
-      try {
-        const stateRequest = SetResolverStateRequest.decode(bytes);
-        stateRequest.sdk = { id: SdkId.SDK_ID_JS_LOCAL_SERVER_PROVIDER, version: VERSION };
-        this.resolver.setResolverState(stateRequest);
-        return;
-      } catch {
-        encrypted = true;
-      }
+    if (encryptionKey) {
+      this.resolver.setEncryptedResolverState({
+        encryptedState: bytes,
+        encryptionKey: hexToBytes(encryptionKey),
+        sdk,
+      });
+    } else {
+      const stateRequest = SetResolverStateRequest.decode(bytes);
+      stateRequest.sdk = sdk;
+      this.resolver.setResolverState(stateRequest);
     }
-
-    const { encryptionKey } = this.options;
-    if (!encryptionKey) {
-      throw new Error(
-        'Resolver state is encrypted but no encryptionKey was provided in ProviderOptions. ' +
-          'Set the encryption key for this client credential.',
-      );
-    }
-    const keyBytes = hexToBytes(encryptionKey);
-    this.resolver.setEncryptedResolverState({
-      encryptedState: bytes,
-      encryptionKey: keyBytes,
-      sdk: { id: SdkId.SDK_ID_JS_LOCAL_SERVER_PROVIDER, version: VERSION },
-    });
   }
 
   // TODO should this return success/failure, or even throw?

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
@@ -4,7 +4,7 @@ import { ResolveProcessRequest, ResolveProcessResponse } from './proto/confidenc
 import { ResolveReason, SdkId } from './proto/confidence/flags/resolver/v1/types';
 import { VERSION } from './version';
 import { Fetch, withLogging, withResponse, withRetry, withRouter, withStallTimeout, withTimeout } from './fetch';
-import { castStringToEnum, scheduleWithFixedInterval, timeoutSignal, TimeUnit } from './util';
+import { castStringToEnum, hexToBytes, scheduleWithFixedInterval, timeoutSignal, TimeUnit } from './util';
 import type { LocalResolver } from './LocalResolver';
 import { sha256Hex } from './hash';
 import { getLogger } from './logger';
@@ -35,6 +35,8 @@ export const DEFAULT_FLUSH_INTERVAL = 15_000;
 export interface SnapshotConfig {}
 export interface ProviderOptions {
   flagClientSecret: string;
+  /** Hex-encoded AES-256 encryption key for decrypting CDN state. */
+  encryptionKey?: string;
   initializeTimeout?: number;
   /** Interval in milliseconds between state polling updates. Defaults to 30000ms. */
   stateUpdateInterval?: number;
@@ -312,12 +314,33 @@ export class ConfidenceServerProviderLocal implements Provider {
     }
     this.stateEtag = resp.headers.get('etag');
 
-    // Parse SetResolverStateRequest from response
     const bytes = new Uint8Array(await resp.arrayBuffer());
+    let encrypted = resp.headers.get('x-amz-meta-encrypted') === 'true';
 
-    const stateRequest = SetResolverStateRequest.decode(bytes);
-    stateRequest.sdk = { id: SdkId.SDK_ID_JS_LOCAL_SERVER_PROVIDER, version: VERSION };
-    this.resolver.setResolverState(stateRequest);
+    if (!encrypted) {
+      try {
+        const stateRequest = SetResolverStateRequest.decode(bytes);
+        stateRequest.sdk = { id: SdkId.SDK_ID_JS_LOCAL_SERVER_PROVIDER, version: VERSION };
+        this.resolver.setResolverState(stateRequest);
+        return;
+      } catch {
+        encrypted = true;
+      }
+    }
+
+    const { encryptionKey } = this.options;
+    if (!encryptionKey) {
+      throw new Error(
+        'Resolver state is encrypted but no encryptionKey was provided in ProviderOptions. ' +
+          'Set the encryption key for this client credential.',
+      );
+    }
+    const keyBytes = hexToBytes(encryptionKey);
+    this.resolver.setEncryptedResolverState({
+      encryptedState: bytes,
+      encryptionKey: keyBytes,
+      sdk: { id: SdkId.SDK_ID_JS_LOCAL_SERVER_PROVIDER, version: VERSION },
+    });
   }
 
   // TODO should this return success/failure, or even throw?

--- a/openfeature-provider/js/src/LocalResolver.ts
+++ b/openfeature-provider/js/src/LocalResolver.ts
@@ -3,13 +3,14 @@ import type {
   ResolveProcessResponse,
   RegisterResolveRequest,
 } from './proto/confidence/wasm/wasm_api';
-import type { SetResolverStateRequest } from './proto/confidence/wasm/messages';
+import type { SetResolverStateRequest, SetEncryptedResolverStateRequest } from './proto/confidence/wasm/messages';
 import type { ApplyFlagsRequest } from './proto/confidence/flags/resolver/v1/api';
 
 export interface LocalResolver {
   resolveProcess(request: ResolveProcessRequest): ResolveProcessResponse;
   registerResolve(request: RegisterResolveRequest): void;
   setResolverState(request: SetResolverStateRequest): void;
+  setEncryptedResolverState(request: SetEncryptedResolverStateRequest): void;
   flushLogs(): Uint8Array;
   flushAssigned(): Uint8Array;
   applyFlags(request: ApplyFlagsRequest): void;

--- a/openfeature-provider/js/src/WasmResolver.test.ts
+++ b/openfeature-provider/js/src/WasmResolver.test.ts
@@ -7,6 +7,8 @@ import { WriteFlagLogsRequest, SdkId } from './proto/test-only';
 
 const moduleBytes = readFileSync(__dirname + '/../../../wasm/confidence_resolver.wasm');
 const stateBytes = readFileSync(__dirname + '/../../../wasm/resolver_state.pb');
+const encryptedStateBytes = readFileSync(__dirname + '/../../../data/resolver_state_encrypted.pb');
+const encryptionKeyHex = readFileSync(__dirname + '/../../../data/encryption_key_test.hex', 'utf8').trim();
 
 const module = new WebAssembly.Module(moduleBytes);
 const CLIENT_SECRET = 'mkjJruAATQWjeY7foFIWfVAcBWnci2YF';
@@ -226,5 +228,41 @@ describe('panic handling', () => {
     const logs = wasmResolver.flushLogs();
 
     expect(logs.length).toBeGreaterThan(0);
+  });
+});
+
+describe('encrypted state', () => {
+  let wasmResolver: WasmResolver;
+
+  beforeEach(() => {
+    wasmResolver = new WasmResolver(module);
+    const keyBytes = new Uint8Array(encryptionKeyHex.match(/.{2}/g)!.map(b => parseInt(b, 16)));
+    wasmResolver.setEncryptedResolverState({
+      encryptedState: encryptedStateBytes,
+      encryptionKey: keyBytes,
+      sdk: { id: SdkId.SDK_ID_JS_LOCAL_SERVER_PROVIDER, version: '0.0.0-test' },
+    });
+  });
+
+  it('should resolve flags after decrypting state', () => {
+    const resp = wasmResolver.resolveProcess(RESOLVE_REQUEST);
+    expect(resp).toMatchObject({
+      resolved: {
+        response: {
+          resolvedFlags: [{ reason: ResolveReason.RESOLVE_REASON_MATCH }],
+        },
+      },
+    });
+  });
+
+  it('should reject wrong encryption key', () => {
+    const freshResolver = new WasmResolver(module);
+    const wrongKey = new Uint8Array(32);
+    expect(() => {
+      freshResolver.setEncryptedResolverState({
+        encryptedState: encryptedStateBytes,
+        encryptionKey: wrongKey,
+      });
+    }).toThrowError('Failed to decrypt');
   });
 });

--- a/openfeature-provider/js/src/WasmResolver.ts
+++ b/openfeature-provider/js/src/WasmResolver.ts
@@ -4,6 +4,7 @@ import {
   Response,
   Void,
   SetResolverStateRequest,
+  SetEncryptedResolverStateRequest,
   PrometheusSnapshotRequest,
   PrometheusSnapshotResponse,
 } from './proto/confidence/wasm/messages';
@@ -30,6 +31,7 @@ const EXPORT_FN_NAMES = [
   'wasm_msg_guest_resolve_flags',
   'wasm_msg_guest_register_resolve',
   'wasm_msg_guest_set_resolver_state',
+  'wasm_msg_guest_set_encrypted_resolver_state',
   'wasm_msg_guest_bounded_flush_logs',
   'wasm_msg_guest_bounded_flush_assign',
   'wasm_msg_guest_apply_flags',
@@ -88,6 +90,12 @@ export class UnsafeWasmResolver implements LocalResolver {
   setResolverState(request: SetResolverStateRequest): void {
     const reqPtr = this.transferRequest(request, SetResolverStateRequest);
     const resPtr = this.exports.wasm_msg_guest_set_resolver_state(reqPtr);
+    this.consumeResponse(resPtr, Void);
+  }
+
+  setEncryptedResolverState(request: SetEncryptedResolverStateRequest): void {
+    const reqPtr = this.transferRequest(request, SetEncryptedResolverStateRequest);
+    const resPtr = this.exports.wasm_msg_guest_set_encrypted_resolver_state(reqPtr);
     this.consumeResponse(resPtr, Void);
   }
 
@@ -184,6 +192,7 @@ export const DEFAULT_DELEGATE_FACTORY: DelegateFactory = module => new UnsafeWas
 export class WasmResolver implements LocalResolver {
   private delegate: LocalResolver;
   private currentState?: { state: Uint8Array; accountId: string };
+  private currentEncryptedState?: SetEncryptedResolverStateRequest;
   private bufferedLogs: Uint8Array[] = [];
 
   constructor(private readonly module: WebAssembly.Module, private delegateFactory = DEFAULT_DELEGATE_FACTORY) {
@@ -199,7 +208,9 @@ export class WasmResolver implements LocalResolver {
     }
 
     this.delegate = this.delegateFactory(this.module);
-    if (this.currentState) {
+    if (this.currentEncryptedState) {
+      this.delegate.setEncryptedResolverState(this.currentEncryptedState);
+    } else if (this.currentState) {
       this.delegate.setResolverState(this.currentState);
     }
   }
@@ -225,8 +236,22 @@ export class WasmResolver implements LocalResolver {
 
   setResolverState(request: SetResolverStateRequest): void {
     this.currentState = request;
+    this.currentEncryptedState = undefined;
     try {
       this.delegate.setResolverState(request);
+    } catch (error: unknown) {
+      if (error instanceof WebAssembly.RuntimeError) {
+        this.reloadInstance(error);
+      }
+      throw error;
+    }
+  }
+
+  setEncryptedResolverState(request: SetEncryptedResolverStateRequest): void {
+    this.currentEncryptedState = request;
+    this.currentState = undefined;
+    try {
+      this.delegate.setEncryptedResolverState(request);
     } catch (error: unknown) {
       if (error instanceof WebAssembly.RuntimeError) {
         this.reloadInstance(error);

--- a/openfeature-provider/js/src/util.ts
+++ b/openfeature-provider/js/src/util.ts
@@ -204,3 +204,14 @@ export function base64FromBytes(arr: Uint8Array): string {
     return globalThis.btoa(bin.join(''));
   }
 }
+
+export function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) {
+    throw new Error('Hex string must have an even number of characters');
+  }
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return bytes;
+}


### PR DESCRIPTION
Depends on #456. Adds encryptionKey option, header+fallback detection, encrypted resolver state methods, crash recovery, and e2e test.