### PR TITLE
feat(rust): support encrypted CDN resolver state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1870,6 +1871,15 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
@@ -2302,8 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "spotify-confidence-openfeature-provider-local"
-version = "0.6.1"
+version = "0.6.0"
 dependencies = [
+ "aes-gcm",
  "arc-swap",
  "async-trait",
  "bytes",

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,6 +109,7 @@ COPY openfeature-provider/go/Cargo.toml ./openfeature-provider/go/
 COPY openfeature-provider/proto/ ./openfeature-provider/proto/
 COPY openfeature-provider/rust/ ./openfeature-provider/rust/
 COPY openfeature-provider/python/Cargo.toml ./openfeature-provider/python/
+COPY data/ ./data/
 
 # Touch files to ensure rebuild (dependencies are cached)
 RUN find . -type f -name "*.rs" -exec touch {} +

--- a/Dockerfile
+++ b/Dockerfile
@@ -627,7 +627,9 @@ FROM openfeature-provider-rust.build AS openfeature-provider-rust.test_e2e
 
 WORKDIR /workspace/openfeature-provider/rust
 RUN --mount=type=secret,id=confidence_client_secret \
+    --mount=type=secret,id=confidence_client_encryption_key \
     CONFIDENCE_CLIENT_SECRET=$(cat /run/secrets/confidence_client_secret) \
+    CONFIDENCE_CLIENT_ENCRYPTION_KEY=$(cat /run/secrets/confidence_client_encryption_key) \
     make test-e2e
 
 # ==============================================================================

--- a/openfeature-provider/rust/Cargo.toml
+++ b/openfeature-provider/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spotify-confidence-openfeature-provider-local"
-version = "0.6.1"
+version = "0.6.0"
 edition = "2021"
 description = "OpenFeature provider for Confidence using native Rust resolver"
 license = "Apache-2.0"
@@ -29,9 +29,10 @@ reqwest = { version = "0.13.1" }
 reqwest-middleware = "0.5.0"
 http = "1.0.0"
 
-# Cryptography for CDN URL hash
+# Cryptography for CDN URL hash and state decryption
 sha2 = "0.10"
 hex = "0.4"
+aes-gcm = "0.10"
 
 # Protobuf and bytes
 prost = "0.12"

--- a/openfeature-provider/rust/src/provider.rs
+++ b/openfeature-provider/rust/src/provider.rs
@@ -216,6 +216,10 @@ impl ConfidenceProvider {
 
     /// Initialize the provider by fetching initial state and starting background tasks.
     pub async fn init(&mut self) -> Result<()> {
+        if self.state_fetcher.encryption_key().is_none() {
+            tracing::warn!("No encryption_key provided. Falling back to unencrypted state. An encryption key will be required in an upcoming version.");
+        }
+
         // Fetch initial state
         let result = self.state_fetcher.fetch().await?;
         if let Some((state, account_id)) = result {

--- a/openfeature-provider/rust/src/provider.rs
+++ b/openfeature-provider/rust/src/provider.rs
@@ -85,6 +85,8 @@ pub struct ProviderOptions {
     /// Confidence endpoints. The original host is preserved in the `X-Forwarded-Host` header.
     /// This is useful for routing through a proxy or mock server.
     pub gateway_url: Option<String>,
+    /// Hex-encoded AES-256 encryption key for decrypting CDN state.
+    pub encryption_key: Option<String>,
 }
 
 impl ProviderOptions {
@@ -98,6 +100,7 @@ impl ProviderOptions {
             assign_flush_interval: None,
             materialization_store: None,
             gateway_url: None,
+            encryption_key: None,
         }
     }
 
@@ -128,6 +131,12 @@ impl ProviderOptions {
     /// Set a gateway URL to route all HTTP requests through.
     pub fn with_gateway_url(mut self, url: impl Into<String>) -> Self {
         self.gateway_url = Some(url.into());
+        self
+    }
+
+    /// Set the hex-encoded AES-256 encryption key for decrypting CDN state.
+    pub fn with_encryption_key(mut self, key: impl Into<String>) -> Self {
+        self.encryption_key = Some(key.into());
         self
     }
 }
@@ -163,6 +172,7 @@ impl ConfidenceProvider {
             client.clone(),
             options.client_secret.clone(),
             Some(sdk.clone()),
+            options.encryption_key,
         ));
         let log_manager = Arc::new(LogManager::new(
             client.clone(),

--- a/openfeature-provider/rust/src/state.rs
+++ b/openfeature-provider/rust/src/state.rs
@@ -48,9 +48,8 @@ impl StateFetcher {
     ) -> Self {
         let hash = Self::hash_client_secret(&client_secret);
         let cdn_url = format!("{}/{}", CDN_BASE_URL, hash);
-        let encryption_key = encryption_key_hex.map(|hex_str| {
-            hex::decode(&hex_str).expect("encryption_key must be valid hex")
-        });
+        let encryption_key = encryption_key_hex
+            .map(|hex_str| hex::decode(&hex_str).expect("encryption_key must be valid hex"));
 
         Self {
             client,
@@ -183,13 +182,11 @@ impl StateFetcher {
         let cipher = Aes256Gcm::new_from_slice(key_bytes)
             .map_err(|e| Error::StateParse(format!("Invalid encryption key: {}", e)))?;
         let nonce = Nonce::from_slice(&data[..12]);
-        cipher
-            .decrypt(nonce, &data[12..])
-            .map_err(|_| {
-                Error::StateParse(
-                    "Failed to decrypt resolver state: invalid key or corrupted data".to_string(),
-                )
-            })
+        cipher.decrypt(nonce, &data[12..]).map_err(|_| {
+            Error::StateParse(
+                "Failed to decrypt resolver state: invalid key or corrupted data".to_string(),
+            )
+        })
     }
 
     /// Get the client secret.
@@ -348,8 +345,7 @@ mod tests {
     #[test]
     fn test_decrypt_encrypted_state() {
         let encrypted = std::fs::read(data_dir().join("resolver_state_encrypted.pb")).unwrap();
-        let hex_key =
-            std::fs::read_to_string(data_dir().join("encryption_key_test.hex")).unwrap();
+        let hex_key = std::fs::read_to_string(data_dir().join("encryption_key_test.hex")).unwrap();
         let key = Some(hex::decode(hex_key.trim()).unwrap());
 
         let decrypted = StateFetcher::decrypt(&encrypted, &key).unwrap();
@@ -363,7 +359,7 @@ mod tests {
 
     #[test]
     fn test_decrypt_rejects_wrong_key() {
-        use aes_gcm::{Aes256Gcm, KeyInit, aead::OsRng};
+        use aes_gcm::{aead::OsRng, Aes256Gcm, KeyInit};
         let encrypted = std::fs::read(data_dir().join("resolver_state_encrypted.pb")).unwrap();
         let wrong_key = Aes256Gcm::generate_key(OsRng).to_vec();
         let result = StateFetcher::decrypt(&encrypted, &Some(wrong_key));

--- a/openfeature-provider/rust/src/state.rs
+++ b/openfeature-provider/rust/src/state.rs
@@ -47,9 +47,13 @@ impl StateFetcher {
         encryption_key_hex: Option<String>,
     ) -> Self {
         let hash = Self::hash_client_secret(&client_secret);
-        let cdn_url = format!("{}/{}", CDN_BASE_URL, hash);
         let encryption_key = encryption_key_hex
             .map(|hex_str| hex::decode(&hex_str).expect("encryption_key must be valid hex"));
+        let cdn_url = if encryption_key.is_some() {
+            format!("{}/{}.enc", CDN_BASE_URL, hash)
+        } else {
+            format!("{}/{}", CDN_BASE_URL, hash)
+        };
 
         Self {
             client,
@@ -109,47 +113,18 @@ impl StateFetcher {
             }
         }
 
-        // Check encryption header
-        let encrypted_header = response
-            .headers()
-            .get("x-amz-meta-encrypted")
-            .and_then(|v| v.to_str().ok())
-            == Some("true");
-
         // Parse response body
         let raw_bytes = response.bytes().await?;
 
-        // Try unencrypted path first (header check + protobuf fallback)
-        let decrypted_bytes = if !encrypted_header {
-            match SetResolverStateRequest::decode(raw_bytes.clone()) {
-                Ok(request) => {
-                    let state_pb = ResolverStatePb::decode(request.state).map_err(|e| {
-                        Error::StateParse(format!("Failed to decode ResolverState: {}", e))
-                    })?;
-                    let state =
-                        ResolverState::from_proto(state_pb, &request.account_id, self.sdk.clone())
-                            .map_err(|e| {
-                                Error::StateParse(format!(
-                                    "Failed to create ResolverState: {:?}",
-                                    e
-                                ))
-                            })?;
-                    return Ok(Some((state, request.account_id)));
-                }
-                Err(_) => {
-                    tracing::warn!("Protobuf decode failed, treating state as encrypted");
-                    Self::decrypt(&raw_bytes, &self.encryption_key)?
-                }
-            }
+        let proto_bytes = if self.encryption_key.is_some() {
+            let decrypted = Self::decrypt(&raw_bytes, &self.encryption_key)?;
+            Bytes::from(decrypted)
         } else {
-            Self::decrypt(&raw_bytes, &self.encryption_key)?
+            raw_bytes
         };
 
-        let request = SetResolverStateRequest::decode(decrypted_bytes.as_slice()).map_err(|e| {
-            Error::StateParse(format!(
-                "Failed to decode decrypted SetResolverStateRequest: {}",
-                e
-            ))
+        let request = SetResolverStateRequest::decode(proto_bytes).map_err(|e| {
+            Error::StateParse(format!("Failed to decode SetResolverStateRequest: {}", e))
         })?;
 
         let state_pb = ResolverStatePb::decode(request.state)
@@ -192,6 +167,11 @@ impl StateFetcher {
     /// Get the client secret.
     pub fn client_secret(&self) -> &str {
         &self.client_secret
+    }
+
+    /// Get the encryption key, if set.
+    pub fn encryption_key(&self) -> Option<&[u8]> {
+        self.encryption_key.as_deref()
     }
 }
 

--- a/openfeature-provider/rust/src/state.rs
+++ b/openfeature-provider/rust/src/state.rs
@@ -48,6 +48,7 @@ impl StateFetcher {
     ) -> Self {
         let hash = Self::hash_client_secret(&client_secret);
         let encryption_key = encryption_key_hex
+            .filter(|s| !s.is_empty())
             .map(|hex_str| hex::decode(&hex_str).expect("encryption_key must be valid hex"));
         let cdn_url = if encryption_key.is_some() {
             format!("{}/{}.enc", CDN_BASE_URL, hash)

--- a/openfeature-provider/rust/src/state.rs
+++ b/openfeature-provider/rust/src/state.rs
@@ -35,13 +35,22 @@ pub struct StateFetcher {
     cdn_url: String,
     etag: RwLock<Option<String>>,
     sdk: Option<Sdk>,
+    encryption_key: Option<Vec<u8>>,
 }
 
 impl StateFetcher {
     /// Create a new state fetcher with the given client, client secret, and sdk identity.
-    pub fn new(client: ClientWithMiddleware, client_secret: String, sdk: Option<Sdk>) -> Self {
+    pub fn new(
+        client: ClientWithMiddleware,
+        client_secret: String,
+        sdk: Option<Sdk>,
+        encryption_key_hex: Option<String>,
+    ) -> Self {
         let hash = Self::hash_client_secret(&client_secret);
         let cdn_url = format!("{}/{}", CDN_BASE_URL, hash);
+        let encryption_key = encryption_key_hex.map(|hex_str| {
+            hex::decode(&hex_str).expect("encryption_key must be valid hex")
+        });
 
         Self {
             client,
@@ -49,6 +58,7 @@ impl StateFetcher {
             cdn_url,
             etag: RwLock::new(None),
             sdk,
+            encryption_key,
         }
     }
 
@@ -100,21 +110,86 @@ impl StateFetcher {
             }
         }
 
+        // Check encryption header
+        let encrypted_header = response
+            .headers()
+            .get("x-amz-meta-encrypted")
+            .and_then(|v| v.to_str().ok())
+            == Some("true");
+
         // Parse response body
-        let bytes = response.bytes().await?;
-        let request = SetResolverStateRequest::decode(bytes).map_err(|e| {
-            Error::StateParse(format!("Failed to decode SetResolverStateRequest: {}", e))
+        let raw_bytes = response.bytes().await?;
+
+        // Try unencrypted path first (header check + protobuf fallback)
+        let decrypted_bytes = if !encrypted_header {
+            match SetResolverStateRequest::decode(raw_bytes.clone()) {
+                Ok(request) => {
+                    let state_pb = ResolverStatePb::decode(request.state).map_err(|e| {
+                        Error::StateParse(format!("Failed to decode ResolverState: {}", e))
+                    })?;
+                    let state =
+                        ResolverState::from_proto(state_pb, &request.account_id, self.sdk.clone())
+                            .map_err(|e| {
+                                Error::StateParse(format!(
+                                    "Failed to create ResolverState: {:?}",
+                                    e
+                                ))
+                            })?;
+                    return Ok(Some((state, request.account_id)));
+                }
+                Err(_) => {
+                    tracing::warn!("Protobuf decode failed, treating state as encrypted");
+                    Self::decrypt(&raw_bytes, &self.encryption_key)?
+                }
+            }
+        } else {
+            Self::decrypt(&raw_bytes, &self.encryption_key)?
+        };
+
+        let request = SetResolverStateRequest::decode(decrypted_bytes.as_slice()).map_err(|e| {
+            Error::StateParse(format!(
+                "Failed to decode decrypted SetResolverStateRequest: {}",
+                e
+            ))
         })?;
 
-        // Parse the inner ResolverState
         let state_pb = ResolverStatePb::decode(request.state)
             .map_err(|e| Error::StateParse(format!("Failed to decode ResolverState: {}", e)))?;
 
-        // Convert to ResolverState
         let state = ResolverState::from_proto(state_pb, &request.account_id, self.sdk.clone())
             .map_err(|e| Error::StateParse(format!("Failed to create ResolverState: {:?}", e)))?;
 
         Ok(Some((state, request.account_id)))
+    }
+
+    /// Decrypt AES-256-GCM encrypted state (Tink NO_PREFIX format).
+    fn decrypt(data: &[u8], key: &Option<Vec<u8>>) -> Result<Vec<u8>> {
+        use aes_gcm::{aead::Aead, Aes256Gcm, KeyInit, Nonce};
+
+        let key_bytes = key.as_ref().ok_or_else(|| {
+            Error::StateParse(
+                "Resolver state is encrypted but no encryption_key was provided. \
+                 Set the encryption key for this client credential."
+                    .to_string(),
+            )
+        })?;
+
+        if data.len() < 12 {
+            return Err(Error::StateParse(
+                "Encrypted state too short (missing nonce)".to_string(),
+            ));
+        }
+
+        let cipher = Aes256Gcm::new_from_slice(key_bytes)
+            .map_err(|e| Error::StateParse(format!("Invalid encryption key: {}", e)))?;
+        let nonce = Nonce::from_slice(&data[..12]);
+        cipher
+            .decrypt(nonce, &data[12..])
+            .map_err(|_| {
+                Error::StateParse(
+                    "Failed to decrypt resolver state: invalid key or corrupted data".to_string(),
+                )
+            })
     }
 
     /// Get the client secret.
@@ -171,6 +246,16 @@ impl Default for SharedState {
 mod tests {
     use super::*;
     use crate::test_utils::{create_minimal_state, create_state_with_flag};
+    use std::path::PathBuf;
+
+    fn data_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("data")
+    }
 
     #[test]
     fn test_hash_client_secret() {
@@ -258,5 +343,38 @@ mod tests {
             shared_state.account_id().await,
             Some("custom-account-id".to_string())
         );
+    }
+
+    #[test]
+    fn test_decrypt_encrypted_state() {
+        let encrypted = std::fs::read(data_dir().join("resolver_state_encrypted.pb")).unwrap();
+        let hex_key =
+            std::fs::read_to_string(data_dir().join("encryption_key_test.hex")).unwrap();
+        let key = Some(hex::decode(hex_key.trim()).unwrap());
+
+        let decrypted = StateFetcher::decrypt(&encrypted, &key).unwrap();
+        let request = SetResolverStateRequest::decode(decrypted.as_slice()).unwrap();
+        assert_eq!(request.account_id, "confidence-test");
+
+        let state_pb = ResolverStatePb::decode(request.state).unwrap();
+        let state = ResolverState::from_proto(state_pb, &request.account_id, None).unwrap();
+        assert!(!state.flags.is_empty());
+    }
+
+    #[test]
+    fn test_decrypt_rejects_wrong_key() {
+        use aes_gcm::{Aes256Gcm, KeyInit, aead::OsRng};
+        let encrypted = std::fs::read(data_dir().join("resolver_state_encrypted.pb")).unwrap();
+        let wrong_key = Aes256Gcm::generate_key(OsRng).to_vec();
+        let result = StateFetcher::decrypt(&encrypted, &Some(wrong_key));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decrypt_rejects_missing_key() {
+        let encrypted = std::fs::read(data_dir().join("resolver_state_encrypted.pb")).unwrap();
+
+        let result = StateFetcher::decrypt(&encrypted, &None);
+        assert!(result.is_err());
     }
 }

--- a/openfeature-provider/rust/tests/e2e.rs
+++ b/openfeature-provider/rust/tests/e2e.rs
@@ -215,24 +215,15 @@ async fn e2e_tests() {
     OpenFeature::singleton_mut().await.shutdown().await;
 }
 
-fn encryption_key() -> Option<String> {
+fn encryption_key() -> String {
     std::env::var("CONFIDENCE_CLIENT_ENCRYPTION_KEY")
-        .ok()
-        .filter(|s| !s.is_empty())
+        .expect("CONFIDENCE_CLIENT_ENCRYPTION_KEY must be set")
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn e2e_encrypted_state() {
-    let enc_key = match encryption_key() {
-        Some(k) => k,
-        None => {
-            eprintln!("CONFIDENCE_CLIENT_ENCRYPTION_KEY not set, skipping");
-            return;
-        }
-    };
-
     let secret = client_secret();
-    let options = ProviderOptions::new(&secret).with_encryption_key(enc_key);
+    let options = ProviderOptions::new(&secret).with_encryption_key(encryption_key());
     let provider = ConfidenceProvider::new(options).expect("Failed to create provider");
 
     let mut ofe = OpenFeature::singleton_mut().await;

--- a/openfeature-provider/rust/tests/e2e.rs
+++ b/openfeature-provider/rust/tests/e2e.rs
@@ -214,3 +214,44 @@ async fn e2e_tests() {
     // Shutdown
     OpenFeature::singleton_mut().await.shutdown().await;
 }
+
+fn encryption_key() -> Option<String> {
+    std::env::var("CONFIDENCE_CLIENT_ENCRYPTION_KEY")
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn e2e_encrypted_state() {
+    let enc_key = match encryption_key() {
+        Some(k) => k,
+        None => {
+            eprintln!("CONFIDENCE_CLIENT_ENCRYPTION_KEY not set, skipping");
+            return;
+        }
+    };
+
+    let secret = client_secret();
+    let options = ProviderOptions::new(&secret).with_encryption_key(enc_key);
+    let provider = ConfidenceProvider::new(options).expect("Failed to create provider");
+
+    let mut ofe = OpenFeature::singleton_mut().await;
+    ofe.set_provider(provider).await;
+    drop(ofe);
+
+    let client = OpenFeature::singleton().await.create_client();
+
+    // Boolean
+    let result = client
+        .get_bool_value("web-sdk-e2e-flag.bool", Some(&context()), None)
+        .await
+        .expect("Failed to resolve bool");
+    assert!(!result, "Expected bool to be false");
+
+    // String
+    let result = client
+        .get_string_value("web-sdk-e2e-flag.str", Some(&context()), None)
+        .await
+        .expect("Failed to resolve string");
+    assert_eq!(result, "control");
+}

--- a/openfeature-provider/rust/tests/e2e.rs
+++ b/openfeature-provider/rust/tests/e2e.rs
@@ -211,38 +211,35 @@ async fn e2e_tests() {
         );
     }
 
-    // Shutdown
+    // Shutdown before re-init with encrypted provider
     OpenFeature::singleton_mut().await.shutdown().await;
-}
 
-fn encryption_key() -> String {
-    std::env::var("CONFIDENCE_CLIENT_ENCRYPTION_KEY")
-        .expect("CONFIDENCE_CLIENT_ENCRYPTION_KEY must be set")
-}
+    // Test: encrypted state resolves correctly
+    {
+        let enc_key = std::env::var("CONFIDENCE_CLIENT_ENCRYPTION_KEY")
+            .expect("CONFIDENCE_CLIENT_ENCRYPTION_KEY must be set");
+        let options = ProviderOptions::new(&secret).with_encryption_key(enc_key);
+        let provider =
+            ConfidenceProvider::new(options).expect("Failed to create encrypted provider");
 
-#[tokio::test(flavor = "multi_thread")]
-async fn e2e_encrypted_state() {
-    let secret = client_secret();
-    let options = ProviderOptions::new(&secret).with_encryption_key(encryption_key());
-    let provider = ConfidenceProvider::new(options).expect("Failed to create provider");
+        let mut ofe = OpenFeature::singleton_mut().await;
+        ofe.set_provider(provider).await;
+        drop(ofe);
 
-    let mut ofe = OpenFeature::singleton_mut().await;
-    ofe.set_provider(provider).await;
-    drop(ofe);
+        let client = OpenFeature::singleton().await.create_client();
 
-    let client = OpenFeature::singleton().await.create_client();
+        let result = client
+            .get_bool_value("web-sdk-e2e-flag.bool", Some(&context()), None)
+            .await
+            .expect("Failed to resolve bool via encrypted state");
+        assert!(!result, "Expected bool to be false (encrypted)");
 
-    // Boolean
-    let result = client
-        .get_bool_value("web-sdk-e2e-flag.bool", Some(&context()), None)
-        .await
-        .expect("Failed to resolve bool");
-    assert!(!result, "Expected bool to be false");
+        let result = client
+            .get_string_value("web-sdk-e2e-flag.str", Some(&context()), None)
+            .await
+            .expect("Failed to resolve string via encrypted state");
+        assert_eq!(result, "control", "Expected string 'control' (encrypted)");
+    }
 
-    // String
-    let result = client
-        .get_string_value("web-sdk-e2e-flag.str", Some(&context()), None)
-        .await
-        .expect("Failed to resolve string");
-    assert_eq!(result, "control");
+    OpenFeature::singleton_mut().await.shutdown().await;
 }


### PR DESCRIPTION
Independent of WASM PR (native resolver). Adds encryption_key to ProviderOptions, AES-256-GCM decryption in StateFetcher, header+fallback detection, and 3 tests.