### PR TITLE
feat(cloudflare): decrypt encrypted CDN state before embedding

### DIFF
--- a/confidence-cloudflare-resolver/deployer/decrypt_state.js
+++ b/confidence-cloudflare-resolver/deployer/decrypt_state.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+// Decrypts AES-256-GCM encrypted resolver state (Tink NO_PREFIX format).
+// Usage: node decrypt_state.js <input_file> <hex_key> [output_file]
+//   If output_file is omitted, decrypted data is written back to input_file.
+const crypto = require('crypto');
+const fs = require('fs');
+
+const [,, inputFile, hexKey, outputFile] = process.argv;
+if (!inputFile || !hexKey) {
+  console.error('Usage: node decrypt_state.js <input_file> <hex_key> [output_file]');
+  process.exit(1);
+}
+
+const encrypted = fs.readFileSync(inputFile);
+const key = Buffer.from(hexKey, 'hex');
+const nonce = encrypted.subarray(0, 12);
+const tag = encrypted.subarray(encrypted.length - 16);
+const ciphertext = encrypted.subarray(12, encrypted.length - 16);
+const decipher = crypto.createDecipheriv('aes-256-gcm', key, nonce);
+decipher.setAuthTag(tag);
+const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+fs.writeFileSync(outputFile || inputFile, plaintext);

--- a/confidence-cloudflare-resolver/deployer/script.sh
+++ b/confidence-cloudflare-resolver/deployer/script.sh
@@ -72,10 +72,14 @@ fi
 
 # Build CDN URL from SHA256 hash of client secret (if not explicitly provided)
 if test -z "$CONFIDENCE_RESOLVER_STATE_URL"; then
-    # Compute SHA256 hash of client secret
     SECRET_HASH=$(printf '%s' "$CONFIDENCE_CLIENT_SECRET" | sha256sum | cut -d' ' -f1)
-    CONFIDENCE_RESOLVER_STATE_URL="${CDN_BASE_URL}/${SECRET_HASH}"
-    echo "📦 Using CDN URL for state: ${CDN_BASE_URL}/<sha256>"
+    if [ -n "$STATE_ENCRYPTION_KEY" ]; then
+        CONFIDENCE_RESOLVER_STATE_URL="${CDN_BASE_URL}/${SECRET_HASH}.enc"
+        echo "🔐 Using encrypted CDN URL for state"
+    else
+        CONFIDENCE_RESOLVER_STATE_URL="${CDN_BASE_URL}/${SECRET_HASH}"
+        echo "⚠️ No STATE_ENCRYPTION_KEY provided. Falling back to unencrypted state. An encryption key will be required in an upcoming version."
+    fi
 fi
 
 # Worker name - prepend prefix if provided
@@ -201,37 +205,14 @@ elif [ "$HTTP_STATUS" = "200" ]; then
     echo "✅ Download of resolver state successful"
     # Extract etag and normalize
     ETAG_RAW=$(awk -F': ' 'tolower($1)=="etag"{print $2}' "$TMP_HEADER" | tr -d '\r')
-    # Check if CDN state is encrypted
-    CDN_ENCRYPTED=$(awk -F': ' 'tolower($1)=="x-amz-meta-encrypted"{print $2}' "$TMP_HEADER" | tr -d '\r')
     rm -f "$TMP_HEADER"
-    # Normalize ETag: drop weak prefix and surrounding quotes, then escape for TOML
     if [ -n "$ETAG_RAW" ]; then
         ETAG_STRIPPED=$(printf '%s' "$ETAG_RAW" | sed -e 's/^W\///' -e 's/^"//' -e 's/"$//')
         ETAG_TOML=$(printf '%s' "$ETAG_STRIPPED" | sed 's/\\/\\\\/g; s/\"/\\\"/g')
     fi
 
-    # Decrypt state if CDN response is encrypted (header check + protobuf parse fallback)
-    NEEDS_DECRYPT="false"
-    if [ "$CDN_ENCRYPTED" = "true" ]; then
-        NEEDS_DECRYPT="true"
-    else
-        # Fallback: try protobuf decode — if it fails, treat as encrypted
-        if ! node -e "
-            const fs = require('fs');
-            const buf = fs.readFileSync('${RESPONSE_FILE}');
-            if (buf.length < 2 || buf[0] !== 0x0a) process.exit(1);
-        " 2>/dev/null; then
-            echo "⚠️ Protobuf decode heuristic failed, treating state as encrypted"
-            NEEDS_DECRYPT="true"
-        fi
-    fi
-
-    if [ "$NEEDS_DECRYPT" = "true" ]; then
-        if [ -z "$STATE_ENCRYPTION_KEY" ]; then
-            echo "❌ Resolver state is encrypted but STATE_ENCRYPTION_KEY is not set."
-            echo "   Set the encryption key for this client credential."
-            exit 1
-        fi
+    # Decrypt if using encrypted state
+    if [ -n "$STATE_ENCRYPTION_KEY" ]; then
         echo "🔐 Decrypting resolver state..."
         SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
         node "$SCRIPT_DIR/decrypt_state.js" "$RESPONSE_FILE" "$STATE_ENCRYPTION_KEY"

--- a/confidence-cloudflare-resolver/deployer/script.sh
+++ b/confidence-cloudflare-resolver/deployer/script.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 CLOUDFLARE_API_TOKEN=${CLOUDFLARE_API_TOKEN:=}
 CLOUDFLARE_ACCOUNT_ID=${CLOUDFLARE_ACCOUNT_ID:=}
 RESOLVE_TOKEN_ENCRYPTION_KEY=${RESOLVE_TOKEN_ENCRYPTION_KEY:=}
+STATE_ENCRYPTION_KEY=${STATE_ENCRYPTION_KEY:=}
 CONFIDENCE_RESOLVER_ALLOWED_ORIGIN=${CONFIDENCE_RESOLVER_ALLOWED_ORIGIN:=}
 CONFIDENCE_RESOLVER_STATE_URL=${CONFIDENCE_RESOLVER_STATE_URL:=}
 CONFIDENCE_CLIENT_SECRET=${CONFIDENCE_CLIENT_SECRET:=}
@@ -200,11 +201,41 @@ elif [ "$HTTP_STATUS" = "200" ]; then
     echo "✅ Download of resolver state successful"
     # Extract etag and normalize
     ETAG_RAW=$(awk -F': ' 'tolower($1)=="etag"{print $2}' "$TMP_HEADER" | tr -d '\r')
+    # Check if CDN state is encrypted
+    CDN_ENCRYPTED=$(awk -F': ' 'tolower($1)=="x-amz-meta-encrypted"{print $2}' "$TMP_HEADER" | tr -d '\r')
     rm -f "$TMP_HEADER"
     # Normalize ETag: drop weak prefix and surrounding quotes, then escape for TOML
     if [ -n "$ETAG_RAW" ]; then
         ETAG_STRIPPED=$(printf '%s' "$ETAG_RAW" | sed -e 's/^W\///' -e 's/^"//' -e 's/"$//')
         ETAG_TOML=$(printf '%s' "$ETAG_STRIPPED" | sed 's/\\/\\\\/g; s/\"/\\\"/g')
+    fi
+
+    # Decrypt state if CDN response is encrypted (header check + protobuf parse fallback)
+    NEEDS_DECRYPT="false"
+    if [ "$CDN_ENCRYPTED" = "true" ]; then
+        NEEDS_DECRYPT="true"
+    else
+        # Fallback: try protobuf decode — if it fails, treat as encrypted
+        if ! node -e "
+            const fs = require('fs');
+            const buf = fs.readFileSync('${RESPONSE_FILE}');
+            if (buf.length < 2 || buf[0] !== 0x0a) process.exit(1);
+        " 2>/dev/null; then
+            echo "⚠️ Protobuf decode heuristic failed, treating state as encrypted"
+            NEEDS_DECRYPT="true"
+        fi
+    fi
+
+    if [ "$NEEDS_DECRYPT" = "true" ]; then
+        if [ -z "$STATE_ENCRYPTION_KEY" ]; then
+            echo "❌ Resolver state is encrypted but STATE_ENCRYPTION_KEY is not set."
+            echo "   Set the encryption key for this client credential."
+            exit 1
+        fi
+        echo "🔐 Decrypting resolver state..."
+        SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+        node "$SCRIPT_DIR/decrypt_state.js" "$RESPONSE_FILE" "$STATE_ENCRYPTION_KEY"
+        echo "✅ Resolver state decrypted"
     fi
 else
     echo "❌ Error downloading resolver state: HTTP status code $HTTP_STATUS"


### PR DESCRIPTION
Independent of WASM PR. Adds decrypt_state.js standalone script and deployer integration. Requires STATE_ENCRYPTION_KEY env var when CDN state is encrypted.

decrypt_state.js usage:
```
node decrypt_state.js <input_file> <hex_key> [output_file]
```
When output_file is omitted, the input file is decrypted in-place.