### PR TITLE
docs(cloudflare): document immediate apply behavior

### DIFF
--- a/confidence-cloudflare-resolver/deployer/README.md
+++ b/confidence-cloudflare-resolver/deployer/README.md
@@ -206,3 +206,7 @@ Resolve rates and latency are always sent to the Confidence backend via `WriteFl
 ## Limitations
 
 * **Sticky assignments**: Not currently supported with the Cloudflare resolver. Flags with sticky assignment rules will return "flag not found".
+
+* **Immediate apply**: The Cloudflare resolver forces `apply=true` on every resolve request, regardless of what the client SDK sends. This means:
+  * Flag exposures are logged immediately at resolve time, before the flag value is rendered or shown to the user.
+  * No resolve token is returned to the client, so the SDK's deferred apply mechanism is effectively disabled — apply calls from the SDK are accepted but silently discarded.


### PR DESCRIPTION
## Summary
- Documents the Cloudflare resolver's `apply=true` behavior in the Limitations section of the deployer README.
- The resolver forces immediate apply on every resolve, returning no resolve token — the SDK's deferred apply calls are silently discarded.

## Test plan
- [ ] Verify README renders correctly on GitHub