### PR TITLE
test: add spec test for fallthrough with read materialization

### DIFF
--- a/confidence-resolver/src/resolver_spec_tests.rs
+++ b/confidence-resolver/src/resolver_spec_tests.rs
@@ -622,6 +622,7 @@ spec_test!(missing_segment_then_match);
 spec_test!(null_targeting_key_then_match);
 spec_test!(no_assignment_then_match);
 spec_test!(fallthrough_with_write_mat);
+spec_test!(fallthrough_with_read_mat_should_not_match_as_variant);
 spec_test!(fallthrough_then_no_match_should_apply);
 
 // Additional materialization tests

--- a/confidence-resolver/test-payloads/resolver-spec/state.json
+++ b/confidence-resolver/test-payloads/resolver-spec/state.json
@@ -1718,6 +1718,29 @@
         }
       ]
     },
+    "flags/fallthrough-read-mat": {
+      "name": "flags/fallthrough-read-mat",
+      "state": "ACTIVE",
+      "clients": ["clients/test-client"],
+      "variants": [{ "name": "treatment", "value": { "color": "red" } }],
+      "rules": [
+        {
+          "name": "flags/fallthrough-read-mat/rules/rule1",
+          "segment": "segments/country-se",
+          "enabled": true,
+          "targetingKeySelector": "targeting_key",
+          "materializationSpec": { "readMaterialization": "materializations/mat1" },
+          "assignmentSpec": { "bucketCount": 1000, "assignments": [{ "assignmentId": "a-ft", "fallthrough": {}, "bucketRanges": [{ "lower": 0, "upper": 1000 }] }] }
+        },
+        {
+          "name": "flags/fallthrough-read-mat/rules/rule2",
+          "segment": "segments/country-se",
+          "enabled": true,
+          "targetingKeySelector": "targeting_key",
+          "assignmentSpec": { "bucketCount": 1000, "assignments": [{ "assignmentId": "a-match", "variant": { "variant": "treatment" }, "bucketRanges": [{ "lower": 0, "upper": 1000 }] }] }
+        }
+      ]
+    },
     "flags/fallthrough-no-match": {
       "name": "flags/fallthrough-no-match",
       "state": "ACTIVE",

--- a/confidence-resolver/test-payloads/resolver-spec/tests.json
+++ b/confidence-resolver/test-payloads/resolver-spec/tests.json
@@ -2257,6 +2257,30 @@
     }
   },
   {
+    "name": "fallthrough_with_read_mat_should_not_match_as_variant",
+    "resolveRequest": {
+      "flags": ["flags/fallthrough-read-mat"],
+      "evaluationContext": { "targeting_key": "user1", "country": "SE" },
+      "clientSecret": "test-secret"
+    },
+    "materializations": {
+      "user1": {
+        "materializations/mat1": {
+          "isUnitInMaterialization": true,
+          "ruleToVariant": {
+            "flags/fallthrough-read-mat/rules/rule1": ""
+          }
+        }
+      }
+    },
+    "expectedResult": {
+      "general": {
+        "resolvedFlags": [{ "flag": "flags/fallthrough-read-mat", "reason": "RESOLVE_REASON_MATCH", "variant": "treatment", "value": { "color": "red" }, "shouldApply": true }],
+        "expectError": null
+      }
+    }
+  },
+  {
     "name": "set_no_match",
     "resolveRequest": {
       "flags": [


### PR DESCRIPTION
## Summary
- Mirrors [epx-flags-resolver#1692](https://ghe.spotify.net/konfidens/epx-flags-resolver/pull/1692) — adds the read-side spec test case
- Ensures a fallthrough assignment with an empty variant in the materialization store does not match as a variant assignment
- Rust resolver already handles this correctly (test passes without production changes)

## Test plan
- [x] `cargo test fallthrough_with_read_mat_should_not_match_as_variant` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)