### PR TITLE
feat(js): decrypt CDN state on host instead of in WASM

### DIFF
--- a/openfeature-provider/js/CLAUDE.md
+++ b/openfeature-provider/js/CLAUDE.md
@@ -10,13 +10,13 @@ TypeScript OpenFeature provider using the Confidence resolver compiled to WASM. 
 
 The package has 5 build targets configured in `tsdown.config.ts`:
 
-| Export Path | Entry File | Platform | WASM Loading |
-|-------------|-----------|----------|-------------|
-| `"."` (default) | `src/index.inlined.ts` | neutral | WASM inlined as data URL |
-| `"./node"` | `src/index.node.ts` | node | `fs.readFile` |
-| `"./fetch"` | `src/index.fetch.ts` | neutral | `fetch()` (Deno, Bun, browsers) |
-| `"./react-server"` | `src/react/server.tsx` | neutral | React Server Component |
-| `"./react-client"` | `src/react/client.tsx` | neutral | React Client Component |
+| Export Path        | Entry File             | Platform | WASM Loading                    |
+| ------------------ | ---------------------- | -------- | ------------------------------- |
+| `"."` (default)    | `src/index.inlined.ts` | neutral  | WASM inlined as data URL        |
+| `"./node"`         | `src/index.node.ts`    | node     | `fs.readFile`                   |
+| `"./fetch"`        | `src/index.fetch.ts`   | neutral  | `fetch()` (Deno, Bun, browsers) |
+| `"./react-server"` | `src/react/server.tsx` | neutral  | React Server Component          |
+| `"./react-client"` | `src/react/client.tsx` | neutral  | React Client Component          |
 
 Each entry point exports a `createConfidenceServerProvider` factory function.
 
@@ -30,8 +30,8 @@ Defined in `src/ConfidenceServerProviderLocal.ts`:
 interface ProviderOptions {
   flagClientSecret: string;
   initializeTimeout?: number;
-  stateUpdateInterval?: number;  // ms between state polls (default: 30000)
-  flushInterval?: number;        // ms between log flushes (default: 15000)
+  stateUpdateInterval?: number; // ms between state polls (default: 30000)
+  flushInterval?: number; // ms between log flushes (default: 15000)
   fetch?: typeof fetch;
   materializationStore?: MaterializationStore | 'CONFIDENCE_REMOTE_STORE';
 }

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.test.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.test.ts
@@ -21,7 +21,6 @@ const mockedWasmResolver: MockedObject<LocalResolver> = {
   resolveProcess: vi.fn(),
   registerResolve: vi.fn(),
   setResolverState: vi.fn(),
-  setEncryptedResolverState: vi.fn(),
   flushLogs: vi.fn().mockReturnValue(new Uint8Array(100)),
   flushAssigned: vi.fn().mockReturnValue(new Uint8Array(50)),
   applyFlags: vi.fn(),

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
@@ -328,17 +328,10 @@ export class ConfidenceServerProviderLocal implements Provider {
       // best-effort: don't block state update if flush fails
     }
 
-    if (encryptionKey) {
-      this.resolver.setEncryptedResolverState({
-        encryptedState: bytes,
-        encryptionKey: hexToBytes(encryptionKey),
-        sdk,
-      });
-    } else {
-      const stateRequest = SetResolverStateRequest.decode(bytes);
-      stateRequest.sdk = sdk;
-      this.resolver.setResolverState(stateRequest);
-    }
+    const plaintext = encryptionKey ? await decryptAesGcm(bytes, hexToBytes(encryptionKey)) : bytes;
+    const stateRequest = SetResolverStateRequest.decode(plaintext);
+    stateRequest.sdk = sdk;
+    this.resolver.setResolverState(stateRequest);
   }
 
   // TODO should this return success/failure, or even throw?
@@ -474,6 +467,18 @@ export class ConfidenceServerProviderLocal implements Provider {
 
     this.resolver.applyFlags(request);
   }
+}
+
+async function decryptAesGcm(data: Uint8Array, rawKey: Uint8Array): Promise<Uint8Array> {
+  const NONCE_LEN = 12;
+  if (data.length < NONCE_LEN) {
+    throw new Error('Encrypted state too short (missing nonce)');
+  }
+  const iv = data.buffer.slice(data.byteOffset, data.byteOffset + NONCE_LEN) as ArrayBuffer;
+  const ciphertext = data.buffer.slice(data.byteOffset + NONCE_LEN, data.byteOffset + data.byteLength) as ArrayBuffer;
+  const key = await crypto.subtle.importKey('raw', rawKey.buffer as ArrayBuffer, 'AES-GCM', false, ['decrypt']);
+  const plaintext = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, ciphertext);
+  return new Uint8Array(plaintext);
 }
 
 function reasonStringToEnum(reason: string): ResolveReason {

--- a/openfeature-provider/js/src/LocalResolver.ts
+++ b/openfeature-provider/js/src/LocalResolver.ts
@@ -3,14 +3,13 @@ import type {
   ResolveProcessResponse,
   RegisterResolveRequest,
 } from './proto/confidence/wasm/wasm_api';
-import type { SetResolverStateRequest, SetEncryptedResolverStateRequest } from './proto/confidence/wasm/messages';
+import type { SetResolverStateRequest } from './proto/confidence/wasm/messages';
 import type { ApplyFlagsRequest } from './proto/confidence/flags/resolver/v1/api';
 
 export interface LocalResolver {
   resolveProcess(request: ResolveProcessRequest): ResolveProcessResponse;
   registerResolve(request: RegisterResolveRequest): void;
   setResolverState(request: SetResolverStateRequest): void;
-  setEncryptedResolverState(request: SetEncryptedResolverStateRequest): void;
   flushLogs(): Uint8Array;
   flushAssigned(): Uint8Array;
   applyFlags(request: ApplyFlagsRequest): void;

--- a/openfeature-provider/js/src/WasmResolver.test.ts
+++ b/openfeature-provider/js/src/WasmResolver.test.ts
@@ -7,8 +7,6 @@ import { WriteFlagLogsRequest, SdkId } from './proto/test-only';
 
 const moduleBytes = readFileSync(__dirname + '/../../../wasm/confidence_resolver.wasm');
 const stateBytes = readFileSync(__dirname + '/../../../wasm/resolver_state.pb');
-const encryptedStateBytes = readFileSync(__dirname + '/../../../data/resolver_state_encrypted.pb');
-const encryptionKeyHex = readFileSync(__dirname + '/../../../data/encryption_key_test.hex', 'utf8').trim();
 
 const module = new WebAssembly.Module(moduleBytes);
 const CLIENT_SECRET = 'mkjJruAATQWjeY7foFIWfVAcBWnci2YF';
@@ -228,41 +226,5 @@ describe('panic handling', () => {
     const logs = wasmResolver.flushLogs();
 
     expect(logs.length).toBeGreaterThan(0);
-  });
-});
-
-describe('encrypted state', () => {
-  let wasmResolver: WasmResolver;
-
-  beforeEach(() => {
-    wasmResolver = new WasmResolver(module);
-    const keyBytes = new Uint8Array(encryptionKeyHex.match(/.{2}/g)!.map(b => parseInt(b, 16)));
-    wasmResolver.setEncryptedResolverState({
-      encryptedState: encryptedStateBytes,
-      encryptionKey: keyBytes,
-      sdk: { id: SdkId.SDK_ID_JS_LOCAL_SERVER_PROVIDER, version: '0.0.0-test' },
-    });
-  });
-
-  it('should resolve flags after decrypting state', () => {
-    const resp = wasmResolver.resolveProcess(RESOLVE_REQUEST);
-    expect(resp).toMatchObject({
-      resolved: {
-        response: {
-          resolvedFlags: [{ reason: ResolveReason.RESOLVE_REASON_MATCH }],
-        },
-      },
-    });
-  });
-
-  it('should reject wrong encryption key', () => {
-    const freshResolver = new WasmResolver(module);
-    const wrongKey = new Uint8Array(32);
-    expect(() => {
-      freshResolver.setEncryptedResolverState({
-        encryptedState: encryptedStateBytes,
-        encryptionKey: wrongKey,
-      });
-    }).toThrowError('Failed to decrypt');
   });
 });

--- a/openfeature-provider/js/src/WasmResolver.ts
+++ b/openfeature-provider/js/src/WasmResolver.ts
@@ -4,7 +4,6 @@ import {
   Response,
   Void,
   SetResolverStateRequest,
-  SetEncryptedResolverStateRequest,
   PrometheusSnapshotRequest,
   PrometheusSnapshotResponse,
 } from './proto/confidence/wasm/messages';
@@ -31,7 +30,6 @@ const EXPORT_FN_NAMES = [
   'wasm_msg_guest_resolve_flags',
   'wasm_msg_guest_register_resolve',
   'wasm_msg_guest_set_resolver_state',
-  'wasm_msg_guest_set_encrypted_resolver_state',
   'wasm_msg_guest_bounded_flush_logs',
   'wasm_msg_guest_bounded_flush_assign',
   'wasm_msg_guest_apply_flags',
@@ -90,12 +88,6 @@ export class UnsafeWasmResolver implements LocalResolver {
   setResolverState(request: SetResolverStateRequest): void {
     const reqPtr = this.transferRequest(request, SetResolverStateRequest);
     const resPtr = this.exports.wasm_msg_guest_set_resolver_state(reqPtr);
-    this.consumeResponse(resPtr, Void);
-  }
-
-  setEncryptedResolverState(request: SetEncryptedResolverStateRequest): void {
-    const reqPtr = this.transferRequest(request, SetEncryptedResolverStateRequest);
-    const resPtr = this.exports.wasm_msg_guest_set_encrypted_resolver_state(reqPtr);
     this.consumeResponse(resPtr, Void);
   }
 
@@ -192,7 +184,6 @@ export const DEFAULT_DELEGATE_FACTORY: DelegateFactory = module => new UnsafeWas
 export class WasmResolver implements LocalResolver {
   private delegate: LocalResolver;
   private currentState?: { state: Uint8Array; accountId: string };
-  private currentEncryptedState?: SetEncryptedResolverStateRequest;
   private bufferedLogs: Uint8Array[] = [];
 
   constructor(private readonly module: WebAssembly.Module, private delegateFactory = DEFAULT_DELEGATE_FACTORY) {
@@ -208,9 +199,7 @@ export class WasmResolver implements LocalResolver {
     }
 
     this.delegate = this.delegateFactory(this.module);
-    if (this.currentEncryptedState) {
-      this.delegate.setEncryptedResolverState(this.currentEncryptedState);
-    } else if (this.currentState) {
+    if (this.currentState) {
       this.delegate.setResolverState(this.currentState);
     }
   }
@@ -236,22 +225,8 @@ export class WasmResolver implements LocalResolver {
 
   setResolverState(request: SetResolverStateRequest): void {
     this.currentState = request;
-    this.currentEncryptedState = undefined;
     try {
       this.delegate.setResolverState(request);
-    } catch (error: unknown) {
-      if (error instanceof WebAssembly.RuntimeError) {
-        this.reloadInstance(error);
-      }
-      throw error;
-    }
-  }
-
-  setEncryptedResolverState(request: SetEncryptedResolverStateRequest): void {
-    this.currentEncryptedState = request;
-    this.currentState = undefined;
-    try {
-      this.delegate.setEncryptedResolverState(request);
     } catch (error: unknown) {
       if (error instanceof WebAssembly.RuntimeError) {
         this.reloadInstance(error);


### PR DESCRIPTION
## Summary
- Move AES-256-GCM decryption of encrypted CDN resolver state from the WASM guest to the JS host using Web Crypto API.
- The `encryptionKey` option and `.enc` CDN path are unchanged.
- The WASM export remains but is no longer called from the JS provider.

## Test plan
- [x] All 185 JS provider tests pass (unit + e2e with encrypted and unencrypted state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)