### PR TITLE
fix(cloudflare): create arm64 release

### DIFF
--- a/confidence-cloudflare-resolver/deployer/README.md
+++ b/confidence-cloudflare-resolver/deployer/README.md
@@ -17,7 +17,7 @@ From the **root of the repository**, run:
 docker build --target confidence-cloudflare-resolver.deployer -t <YOUR_IMAGE_NAME> .
 ```
 
-A pre-built image is also available at `ghcr.io/spotify/confidence-cloudflare-deployer:latest`.
+A pre-built image is also available at `ghcr.io/spotify/confidence-cloudflare-deployer:latest` for both `linux/amd64` and `linux/arm64`.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- Adds `linux/arm64` to the deployer image build platforms so it runs natively on Apple Silicon without emulation.
- Updates deployer README to document multi-arch support.

Closes #300

## Test plan
- [x] Verify CI passes
- [ ] On next `confidence-cloudflare-resolver` release, confirm the pushed image has both `linux/amd64` and `linux/arm64` manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)