### PR TITLE
docs: add encryption documentation to provider READMEs

### DIFF
--- a/openfeature-provider/INTEGRATION_GUIDE.md
+++ b/openfeature-provider/INTEGRATION_GUIDE.md
@@ -13,9 +13,10 @@ For language-specific installation and quick start instructions, see your provid
 ## Table of Contents
 
 1. [Getting Your Credentials](#getting-your-credentials)
-2. [Error Handling](#error-handling)
-3. [Sticky Assignments](#sticky-assignments)
-4. [Deferred Apply and Resolve Token Security](#deferred-apply-and-resolve-token-security)
+2. [Encryption](#encryption)
+3. [Error Handling](#error-handling)
+4. [Sticky Assignments](#sticky-assignments)
+5. [Deferred Apply and Resolve Token Security](#deferred-apply-and-resolve-token-security)
 
 ---
 
@@ -26,6 +27,38 @@ Before integrating any Confidence provider, you'll need a **client secret** from
 1. Log into the Confidence dashboard
 2. In the **Clients** section, create a new client secret for the client you intend to use (or start by creating a new client)
 3. Make sure to select **Backend** as integration type. Never expose your Backend client secret outside your organization
+
+---
+
+## Encryption
+
+The flag state downloaded by local-resolve providers contains your flag rules and targeting segments. To protect this data at rest and in transit, Confidence supports **encrypting the flag state**. The state is decrypted only when it is loaded into the resolver component inside the provider — it is never stored or transmitted in plaintext.
+
+### Getting Your Encryption Key
+
+The encryption key is available in the [Confidence Admin view](https://app.confidence.spotify.com/admin/clients), next to the client credentials for your integration.
+
+### Migration
+
+Encryption support was introduced in the following provider versions:
+
+| Provider | Version | Package |
+|----------|---------|---------|
+| JavaScript | `0.16.0` | `@spotify-confidence/openfeature-server-provider-local` |
+| Java | `0.16.0` | `com.spotify.confidence:openfeature-provider-local` |
+| Go | `0.19.0` | `github.com/spotify/confidence-resolver/openfeature-provider/go` |
+| Python | `0.9.0` | `confidence-openfeature-provider` |
+| Rust | `0.7.0` | `spotify-confidence-openfeature-provider-local` |
+
+We strongly recommend enabling encryption now by passing the encryption key when creating your provider. See your provider's README for the exact configuration:
+
+- [JavaScript](js/README.md#encryption)
+- [Java](java/README.md#encryption)
+- [Go](go/README.md#encryption)
+- [Python](python/README.md#encryption)
+- [Rust](rust/README.md#encryption)
+
+> **⚠️ Upcoming change:** Encryption will be made **mandatory** in a future SDK release. We will communicate a timeline and migration path before legacy (unencrypted) provider versions are affected. Adopting encryption now ensures a smooth transition when that happens.
 
 ---
 

--- a/openfeature-provider/go/README.md
+++ b/openfeature-provider/go/README.md
@@ -35,6 +35,25 @@ You'll need a **client secret** from Confidence to use this provider.
 - Creating a test flag for verification
 - Best practices for credential storage
 
+## Encryption
+
+The provider supports encrypting the flag state to protect your flag rules and targeting segments at rest and in transit. The state is decrypted only when loaded into the resolver.
+
+**📖 See the [Integration Guide: Encryption](../INTEGRATION_GUIDE.md#encryption)** for background and migration details.
+
+Pass the encryption key in `ProviderConfig`:
+
+```go
+provider, err := confidence.NewProvider(ctx, confidence.ProviderConfig{
+    ClientSecret:  "your-client-secret",
+    EncryptionKey: "your-encryption-key", // Get from Confidence Admin view
+})
+```
+
+The encryption key is available in the [Confidence Admin view](https://app.confidence.spotify.com/admin/clients), next to your client credentials.
+
+> **⚠️ Upcoming change:** Encryption will be made **mandatory** in a future SDK release. We will communicate a timeline and migration path before legacy provider versions are affected. We strongly recommend enabling it now.
+
 ## Quick Start
 
 ```go
@@ -158,6 +177,7 @@ The `ProviderConfig` struct contains all configuration options for the provider:
 #### Required Fields
 
 - `ClientSecret` (string): The client secret used for authentication and flag evaluation
+- `EncryptionKey` (string): Encryption key for decrypting the flag state. Found in the [Confidence Admin view](https://app.confidence.spotify.com/admin/clients). Will be required in a future release.
 
 #### Optional Fields
 

--- a/openfeature-provider/java/README.md
+++ b/openfeature-provider/java/README.md
@@ -36,6 +36,27 @@ You'll need a **client secret** from Confidence to use this provider.
 - Creating a test flag for verification
 - Best practices for credential storage
 
+## Encryption
+
+The provider supports encrypting the flag state to protect your flag rules and targeting segments at rest and in transit. The state is decrypted only when loaded into the resolver.
+
+**📖 See the [Integration Guide: Encryption](../INTEGRATION_GUIDE.md#encryption)** for background and migration details.
+
+Pass the encryption key via `LocalProviderConfig`:
+
+```java
+LocalProviderConfig config = LocalProviderConfig.builder()
+    .encryptionKey("your-encryption-key") // Get from Confidence Admin view
+    .build();
+
+OpenFeatureLocalResolveProvider provider =
+    new OpenFeatureLocalResolveProvider(config, "your-client-secret");
+```
+
+The encryption key is available in the [Confidence Admin view](https://app.confidence.spotify.com/admin/clients), next to your client credentials.
+
+> **⚠️ Upcoming change:** Encryption will be made **mandatory** in a future SDK release. We will communicate a timeline and migration path before legacy provider versions are affected. We strongly recommend enabling it now.
+
 ## Quick Start
 
 ```java
@@ -122,6 +143,7 @@ Use `LocalProviderConfig.builder()` to configure the provider:
 
 ```java
 LocalProviderConfig config = LocalProviderConfig.builder()
+    .encryptionKey("your-encryption-key") // Encryption key for decrypting flag state (will be required in a future release)
     .resolverPoolSize(4) // Number of WASM resolver instances (default: 2). Increase for higher concurrency.
     .build();
 

--- a/openfeature-provider/js/README.md
+++ b/openfeature-provider/js/README.md
@@ -46,6 +46,27 @@ You'll need a **client secret** from Confidence to use this provider.
 
 ---
 
+## Encryption
+
+The provider supports encrypting the flag state to protect your flag rules and targeting segments at rest and in transit. The state is decrypted only when loaded into the resolver.
+
+**📖 See the [Integration Guide: Encryption](../INTEGRATION_GUIDE.md#encryption)** for background and migration details.
+
+Pass the encryption key when creating the provider:
+
+```ts
+const provider = createConfidenceServerProvider({
+  flagClientSecret: process.env.CONFIDENCE_FLAG_CLIENT_SECRET!,
+  encryptionKey: process.env.CONFIDENCE_ENCRYPTION_KEY!,
+});
+```
+
+The encryption key is available in the [Confidence Admin view](https://app.confidence.spotify.com/admin/clients), next to your client credentials.
+
+> **⚠️ Upcoming change:** Encryption will be made **mandatory** in a future SDK release. We will communicate a timeline and migration path before legacy provider versions are affected. We strongly recommend enabling it now.
+
+---
+
 ## Quick start (Node)
 
 ```ts
@@ -135,6 +156,7 @@ if (details.errorCode) {
 ## Options
 
 - `flagClientSecret` (string, required): The flag client secret used during evaluation and authentication.
+- `encryptionKey` (string, optional): Encryption key for decrypting the flag state. Found in the [Confidence Admin view](https://app.confidence.spotify.com/admin/clients). Will be required in a future release (see [Encryption](#encryption)).
 - `initializeTimeout` (number, optional): Max ms to wait for initial state fetch. Defaults to 30_000.
 - `stateUpdateInterval` (number, optional): Interval in ms between state polling updates. Defaults to 30_000.
 - `flushInterval` (number, optional): Interval in ms for sending evaluation logs. Defaults to 10_000.

--- a/openfeature-provider/python/README.md
+++ b/openfeature-provider/python/README.md
@@ -33,6 +33,25 @@ You'll need a **client secret** from Confidence to use this provider.
 - Creating a test flag for verification
 - Best practices for credential storage
 
+## Encryption
+
+The provider supports encrypting the flag state to protect your flag rules and targeting segments at rest and in transit. The state is decrypted only when loaded into the resolver.
+
+**📖 See the [Integration Guide: Encryption](../INTEGRATION_GUIDE.md#encryption)** for background and migration details.
+
+Pass the encryption key when creating the provider:
+
+```python
+provider = ConfidenceProvider(
+    client_secret="your-client-secret",
+    encryption_key="your-encryption-key",  # Get from Confidence Admin view
+)
+```
+
+The encryption key is available in the [Confidence Admin view](https://app.confidence.spotify.com/admin/clients), next to your client credentials.
+
+> **⚠️ Upcoming change:** Encryption will be made **mandatory** in a future SDK release. We will communicate a timeline and migration path before legacy provider versions are affected. We strongly recommend enabling it now.
+
 ## Quick Start
 
 ```python
@@ -130,6 +149,7 @@ provider = ConfidenceProvider(
 ### Configuration Options
 
 - `client_secret` (str, required): The Confidence client secret for authentication.
+- `encryption_key` (str, optional): Encryption key for decrypting the flag state. Found in the [Confidence Admin view](https://app.confidence.spotify.com/admin/clients). Will be required in a future release.
 - `state_poll_interval` (float, optional): Interval in seconds between state polling updates. Defaults to 30.0.
 - `log_poll_interval` (float, optional): Interval in seconds for sending evaluation logs. Defaults to 10.0.
 - `use_remote_materialization_store` (bool, optional): Enable remote materialization storage. Defaults to False.

--- a/openfeature-provider/rust/README.md
+++ b/openfeature-provider/rust/README.md
@@ -41,6 +41,23 @@ You'll need a **client secret** from Confidence to use this provider.
 - Creating a test flag for verification
 - Best practices for credential storage
 
+## Encryption
+
+The provider supports encrypting the flag state to protect your flag rules and targeting segments at rest and in transit. The state is decrypted only when loaded into the resolver.
+
+**See the [Integration Guide: Encryption](../INTEGRATION_GUIDE.md#encryption)** for background and migration details.
+
+Pass the encryption key via `ProviderOptions`:
+
+```rust
+let options = ProviderOptions::new("your-client-secret")
+    .with_encryption_key("your-encryption-key"); // Get from Confidence Admin view
+```
+
+The encryption key is available in the [Confidence Admin view](https://app.confidence.spotify.com/admin/clients), next to your client credentials.
+
+> **⚠️ Upcoming change:** Encryption will be made **mandatory** in a future SDK release. We will communicate a timeline and migration path before legacy provider versions are affected. We strongly recommend enabling it now.
+
 ## Quick Start
 
 ```rust
@@ -154,6 +171,7 @@ let options = ProviderOptions::new("your-client-secret")
 #### Required Fields
 
 - `client_secret` (String): The client secret used for authentication and flag evaluation
+- `encryption_key` (Option\<String\>): Encryption key for decrypting the flag state. Found in the [Confidence Admin view](https://app.confidence.spotify.com/admin/clients). Will be required in a future release.
 
 #### Optional Fields
 


### PR DESCRIPTION
## Summary

- Adds an Encryption section to the shared Integration Guide with version table, migration guidance, and links to each provider
- Adds provider-specific Encryption sections (with code examples) to JS, Java, Go, Python, and Rust READMEs
- Documents `encryptionKey` in each provider's configuration/options reference

## Test plan

- [ ] Verify all internal README links resolve correctly
- [ ] Confirm version numbers match the release that shipped encryption support

🤖 Generated with [Claude Code](https://claude.com/claude-code)