### PR TITLE
fix(openfeature-provider/go): send If-Modified-Since when fetching state

### DIFF
--- a/openfeature-provider/go/confidence/state_fetcher.go
+++ b/openfeature-provider/go/confidence/state_fetcher.go
@@ -27,6 +27,7 @@ type FlagsAdminStateFetcher struct {
 	clientSecret     string
 	encryptionKey    string
 	etag             atomic.Value // stores string
+	lastModified     atomic.Value // stores string
 	rawResolverState atomic.Value // stores []byte
 	accountID        atomic.Value // stores string
 	HTTPClient       *http.Client // Exported for testing
@@ -126,9 +127,15 @@ func (f *FlagsAdminStateFetcher) fetchAndUpdateStateIfChanged(ctx context.Contex
 		return err
 	}
 
-	// Add If-None-Match header if we have a previous ETag
-	if previousEtag := f.etag.Load(); previousEtag != nil {
-		req.Header.Set("If-None-Match", previousEtag.(string))
+	// Add If-None-Match header if we have a previous ETag. Also send
+	// If-Modified-Since as a fallback: some network paths (e.g. proxies that
+	// rewrite or strip ETags) break ETag validation while date-based
+	// validation still works.
+	if previousEtag, ok := f.etag.Load().(string); ok && previousEtag != "" {
+		req.Header.Set("If-None-Match", previousEtag)
+	}
+	if lastModified, ok := f.lastModified.Load().(string); ok && lastModified != "" {
+		req.Header.Set("If-Modified-Since", lastModified)
 	}
 
 	resp, err := f.HTTPClient.Do(req)
@@ -170,6 +177,7 @@ func (f *FlagsAdminStateFetcher) fetchAndUpdateStateIfChanged(ctx context.Contex
 	f.accountID.Store(clientState.Account)
 	f.rawResolverState.Store(clientState.State)
 	f.etag.Store(etag)
+	f.lastModified.Store(resp.Header.Get("Last-Modified"))
 	f.logger.Debug("Loaded resolver state", "etag", etag, "account", clientState.Account)
 	return nil
 }

--- a/openfeature-provider/go/confidence/state_fetcher_test.go
+++ b/openfeature-provider/go/confidence/state_fetcher_test.go
@@ -194,6 +194,107 @@ func TestFlagsAdminStateFetcher_Reload_NotModified(t *testing.T) {
 	}
 }
 
+// TestFlagsAdminStateFetcher_Reload_IfModifiedSinceFallback tests that
+// date-based caching still works when ETag validation is broken (e.g. a proxy
+// strips or rewrites If-None-Match)
+func TestFlagsAdminStateFetcher_Reload_IfModifiedSinceFallback(t *testing.T) {
+	const lastModified = "Mon, 03 Aug 2026 12:00:00 GMT"
+	requestCount := 0
+	testState := &adminv1.ResolverState{Flags: []*adminv1.Flag{
+		{Name: "flags/test-flag"},
+	}}
+	testStateBytes, _ := proto.Marshal(testState)
+	stateRequest := &adminv1.ClientResolverState{
+		State:   testStateBytes,
+		Account: "test-account",
+	}
+	stateBytes, _ := proto.Marshal(stateRequest)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+
+		// Ignore If-None-Match entirely; only honor If-Modified-Since
+		if r.Header.Get("If-Modified-Since") == lastModified {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+
+		w.Header().Set("ETag", "test-etag")
+		w.Header().Set("Last-Modified", lastModified)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(stateBytes)
+	}))
+	defer server.Close()
+
+	fetcher := NewFlagsAdminStateFetcher("test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	fetcher.HTTPClient = &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: &testTransport{testServerURL: server.URL},
+	}
+	ctx := context.Background()
+
+	if err := fetcher.Reload(ctx); err != nil {
+		t.Errorf("Expected no error on first reload, got %v", err)
+	}
+	if err := fetcher.Reload(ctx); err != nil {
+		t.Errorf("Expected no error on second reload, got %v", err)
+	}
+
+	if requestCount != 2 {
+		t.Errorf("Expected 2 HTTP requests, got %d", requestCount)
+	}
+	if lm := fetcher.lastModified.Load(); lm == nil || lm.(string) != lastModified {
+		t.Error("Expected Last-Modified to be stored")
+	}
+}
+
+// TestFlagsAdminStateFetcher_Reload_NoValidators tests that no conditional
+// headers are sent when the server never returned ETag or Last-Modified
+func TestFlagsAdminStateFetcher_Reload_NoValidators(t *testing.T) {
+	testState := &adminv1.ResolverState{Flags: []*adminv1.Flag{
+		{Name: "flags/test-flag"},
+	}}
+	testStateBytes, _ := proto.Marshal(testState)
+	stateRequest := &adminv1.ClientResolverState{
+		State:   testStateBytes,
+		Account: "test-account",
+	}
+	stateBytes, _ := proto.Marshal(stateRequest)
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount > 1 {
+			if _, present := r.Header["If-None-Match"]; present {
+				t.Error("Expected no If-None-Match header when no ETag was received")
+			}
+			if _, present := r.Header["If-Modified-Since"]; present {
+				t.Error("Expected no If-Modified-Since header when no Last-Modified was received")
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(stateBytes)
+	}))
+	defer server.Close()
+
+	fetcher := NewFlagsAdminStateFetcher("test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	fetcher.HTTPClient = &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: &testTransport{testServerURL: server.URL},
+	}
+	ctx := context.Background()
+
+	if err := fetcher.Reload(ctx); err != nil {
+		t.Errorf("Expected no error on first reload, got %v", err)
+	}
+	if err := fetcher.Reload(ctx); err != nil {
+		t.Errorf("Expected no error on second reload, got %v", err)
+	}
+	if requestCount != 2 {
+		t.Errorf("Expected 2 HTTP requests, got %d", requestCount)
+	}
+}
+
 // TestFlagsAdminStateFetcher_Reload_Error tests error handling
 func TestFlagsAdminStateFetcher_Reload_Error(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

A customer reported that the Go provider re-downloads the full resolver state (~5.6 MB for large accounts) on every 10s poll even when the state is unchanged, despite sending `If-None-Match`.

Root cause: the state CDN hostname is GSLB-steered between two CDN vendors. The Fastly leg honors `If-None-Match`, but the Akamai leg only performs ETag revalidation when the optional [Validate Entity Tag](https://techdocs.akamai.com/property-mgr/docs/val-entity-tag) behavior is enabled on the property — by default it only honors `Last-Modified`/`If-Modified-Since`. Clients steered to Akamai (observed from Europe) get 200 + full body on effectively every poll for frequently republished states.

## Change

- Store the `Last-Modified` response header and send `If-Modified-Since` alongside `If-None-Match` on state fetches. Date-based validation is the default revalidation mechanism on the affected CDN leg, so this restores 304 + zero-byte polls there while leaving ETag validation in place where it works.
- Stop sending conditional headers with empty values when the server returned no validator.

Verified against the affected edge with the reporting customer's state object: requests carrying both validators receive `304` with an empty body where `If-None-Match` alone receives `200` with the full 5.6 MB state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)