### PR TITLE
fix(openfeature-provider/go): skip WASM state update when state unchanged

### DIFF
--- a/openfeature-provider/go/confidence/provider.go
+++ b/openfeature-provider/go/confidence/provider.go
@@ -1,6 +1,7 @@
 package confidence
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -498,7 +499,7 @@ func (p *LocalResolverProvider) Init(evaluationContext openfeature.EvaluationCon
 	}
 
 	// Start background tasks for state updates and log flushing
-	p.startScheduledTasks(ctx)
+	p.startScheduledTasks(ctx, initialState, accountId)
 
 	p.logger.Info("Provider initialized successfully")
 	return nil
@@ -550,7 +551,7 @@ func (p *LocalResolverProvider) Shutdown() {
 }
 
 // startScheduledTasks starts the background tasks for state fetching and log polling
-func (p *LocalResolverProvider) startScheduledTasks(parentCtx context.Context) {
+func (p *LocalResolverProvider) startScheduledTasks(parentCtx context.Context, appliedState []byte, appliedAccountId string) {
 	ctx, cancel := context.WithCancel(parentCtx)
 	p.mu.Lock()
 	p.cancelFunc = cancel
@@ -578,6 +579,13 @@ func (p *LocalResolverProvider) startScheduledTasks(parentCtx context.Context) {
 					continue
 				}
 
+				// Skip the WASM state update if nothing changed (e.g. the fetch
+				// was answered with 304 Not Modified). Re-ingesting identical
+				// state churns the WASM heap for no benefit (#455).
+				if accountId == appliedAccountId && bytes.Equal(state, appliedState) {
+					continue
+				}
+
 				// Flush logs before state update to reduce WASM heap fragmentation (#455)
 				if err := p.resolver.FlushAllLogs(); err != nil {
 					p.logger.Error("Failed to flush logs before state update", "error", err)
@@ -594,7 +602,10 @@ func (p *LocalResolverProvider) startScheduledTasks(parentCtx context.Context) {
 				}
 				if err := p.resolver.SetResolverState(setResolverStateRequest); err != nil {
 					p.logger.Error("Failed to update state", "error", err)
+					continue
 				}
+				appliedState = state
+				appliedAccountId = accountId
 			case <-ctx.Done():
 				return
 			}


### PR DESCRIPTION
## Summary

Companion to #500. The state poll loop called `SetResolverState` on every tick even when the CDN fetch returned `304 Not Modified` — `Provide()` gives no change signal, so an identical state was re-ingested into the WASM guest every 10 seconds (default `StatePollInterval`).

Re-ingesting identical state churns the guest heap and is exactly the state-update/resolve interleaving behind the fragmentation growth in #455, which #469 mitigated but did not remove.

## Change

Track the last applied state bytes and account ID in the poll loop and skip the log flush + `SetResolverState` when nothing changed (`bytes.Equal` short-circuits on the identical slice returned after a 304). On a failed update the previous values are kept, so the update is retried on the next tick.

Custom `StateProvider` implementations that return fresh but identical byte slices also benefit; ones returning new data behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)