### PR TITLE
fix(openfeature-provider/go): release with synced WASM module

### DIFF
--- a/openfeature-provider/go/README.md
+++ b/openfeature-provider/go/README.md
@@ -24,6 +24,8 @@ go mod tidy
 - Go 1.24+
 - OpenFeature Go SDK 1.16.0+
 
+> **Note:** Use v0.20.1 or later; the v0.20.0 tag shipped with an out-of-sync embedded WASM module.
+
 ## Getting Your Credentials
 
 You'll need a **client secret** from Confidence to use this provider.


### PR DESCRIPTION
## Summary

The `openfeature-provider/go/v0.20.0` tag shipped with a stale embedded WASM module — the sync landed only after the release merged (#503).

Two release-please quirks mean #503 alone can't produce a corrected release:
- it was squash-merged as a `chore:` commit, which doesn't trigger a version bump
- the WASM asset is in the Go package's `exclude-paths`, so even a `fix:` touching only the WASM wouldn't count

Re-tagging v0.20.0 isn't an option either — the Go module proxy has already cached it immutably, so moving the tag would break consumers with checksum mismatches.

This PR is a minimal `fix(openfeature-provider/go)` commit (a README note warning about v0.20.0) to make release-please open a **v0.20.1** release PR. That tag will include the synced WASM from #503.

## After merging

Merge the release-please PR it generates to cut `openfeature-provider/go/v0.20.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)