### PR TITLE
fix(go): prevent silent crash during concurrent WASM recovery

### DIFF
--- a/openfeature-provider/go/confidence/internal/local_resolver/recover.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/recover.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolver"
 	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/wasm"
@@ -35,9 +35,9 @@ func (f *RecoveringResolverFactory) New() LocalResolver {
 // resolver can be reinitialized before use.
 type RecoveringResolver struct {
 	factory LocalResolverFactory
+	mu      sync.Mutex
 
 	current atomic.Value // holds LocalResolver
-	broken  atomic.Bool  // indicates an instance has panicked
 
 	lastState atomic.Value // holds *wasm.SetResolverStateRequest
 }
@@ -49,38 +49,34 @@ func (r *RecoveringResolver) get() LocalResolver {
 	return nil
 }
 
-// startRecreate starts a background recreation.
-// It replaces the current resolver with a fresh one and reapplies last state.
-// Old instance is closed in a best-effort goroutine with a short timeout.
-func (r *RecoveringResolver) startRecreate() {
-	go func() {
-		defer r.broken.Store(false)
-		defer func() {
-			recover() // factory.New() may panic if the runtime was already closed
-		}()
-		old := r.get()
-		newLR := r.factory.New()
-		if v := r.lastState.Load(); v != nil {
-			state := v.(*wasm.SetResolverStateRequest)
-			_ = newLR.SetResolverState(state)
-		}
-		r.current.Store(newLR)
-		if old != nil {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-			defer cancel()
-			_ = old.Close(ctx)
-		}
+// recreateLocked swaps in a fresh resolver and closes the old one in the
+// background. The caller must hold r.mu so no other operation uses old.
+func (r *RecoveringResolver) recreateLocked() {
+	defer func() {
+		recover() // factory.New() may panic if the runtime was already closed
 	}()
+	old := r.get()
+	newLR := r.factory.New()
+	if v := r.lastState.Load(); v != nil {
+		state := v.(*wasm.SetResolverStateRequest)
+		_ = newLR.SetResolverState(state)
+	}
+	r.current.Store(newLR)
+	if old != nil {
+		go func() {
+			_ = old.Close(context.Background())
+		}()
+	}
 }
 
 // withRecover ensures a resolver exists, executes fn, and sets setErr on panic or recreation failure.
 func (r *RecoveringResolver) withRecover(opName string, setErr *error, fn func(LocalResolver)) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	defer func() {
 		if rec := recover(); rec != nil {
-			// mark broken and kick off background recreation once
-			if r.broken.CompareAndSwap(false, true) {
-				r.startRecreate()
-			}
+			r.recreateLocked()
 			if setErr != nil {
 				*setErr = fmt.Errorf("resolver panicked during %s: %v", opName, rec)
 			}
@@ -101,15 +97,17 @@ func (r *RecoveringResolver) SetResolverState(request *wasm.SetResolverStateRequ
 }
 
 func (r *RecoveringResolver) RegisterResolve(request *wasm.RegisterResolveRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	defer func() {
 		if rec := recover(); rec != nil {
 			slog.Warn("RegisterResolve panicked, ignoring", "error", rec)
 		}
 	}()
-	if r.broken.Load() {
+	lr := r.get()
+	if lr == nil {
 		return
 	}
-	lr := r.get()
 	lr.RegisterResolve(request)
 }
 
@@ -142,24 +140,25 @@ func (r *RecoveringResolver) FlushAssignLogs() (err error) {
 }
 
 func (r *RecoveringResolver) PrometheusSnapshot(bucketsPerDecade uint32, openmetrics bool) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	defer func() {
 		if rec := recover(); rec != nil {
 			slog.Warn("PrometheusSnapshot panicked, ignoring", "error", rec)
 		}
 	}()
-	if r.broken.Load() {
+	lr := r.get()
+	if lr == nil {
 		return ""
 	}
-	lr := r.get()
 	return lr.PrometheusSnapshot(bucketsPerDecade, openmetrics)
 }
 
 func (r *RecoveringResolver) Close(ctx context.Context) error {
-	// For Close, if we panic, don't recreate during shutdown; just surface error.
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	defer func() {
-		if rec := recover(); rec != nil {
-			// swallowing recreate on shutdown
-		}
+		recover()
 	}()
 	lr := r.get()
 	if lr == nil {

--- a/openfeature-provider/go/confidence/internal/local_resolver/recover_test.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/recover_test.go
@@ -2,9 +2,9 @@ package local_resolver
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolver"
 	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/wasm"
@@ -53,34 +53,48 @@ func TestRecoveringResolver_RecreatesAfterPanic(t *testing.T) {
 	factory := NewRecoveringResolverFactory(inner)
 	rr := factory.New()
 
-	// First call: the mockResolver (shouldPanic=true) panics, withRecover
-	// catches it and kicks off background recreation.
+	// First call: the mockResolver (shouldPanic=true) panics; withRecover
+	// recreates synchronously before returning.
 	_, err := rr.ResolveProcess(&wasm.ResolveProcessRequest{})
 	if err == nil {
 		t.Fatal("expected error from panicking resolver")
-	}
-
-	// Wait for the background goroutine in startRecreate to finish.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if inner.count.Load() >= 2 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
 	}
 
 	if inner.count.Load() < 2 {
 		t.Fatal("factory was never called to recreate the resolver")
 	}
 
-	// Give the goroutine a moment to finish storing the new resolver
-	// after factory.New() returned.
-	time.Sleep(50 * time.Millisecond)
-
 	// Second call: should succeed because the recovered resolver is a
 	// fresh mockResolver(shouldPanic=false) from the inner factory.
 	_, err = rr.ResolveProcess(&wasm.ResolveProcessRequest{})
 	if err != nil {
 		t.Fatalf("expected successful resolve after recovery, got: %v", err)
+	}
+}
+
+// TestRecoveringResolver_ConcurrentResolveDuringRecovery verifies that a
+// concurrent resolve cannot observe a half-swapped or closed WASM instance.
+func TestRecoveringResolver_ConcurrentResolveDuringRecovery(t *testing.T) {
+	inner := &mockFactory{}
+	factory := NewRecoveringResolverFactory(inner)
+	rr := factory.New()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	for range 2 {
+		go func() {
+			defer wg.Done()
+			_, _ = rr.ResolveProcess(&wasm.ResolveProcessRequest{})
+		}()
+	}
+	wg.Wait()
+
+	if inner.count.Load() < 2 {
+		t.Fatal("expected resolver recreation during concurrent resolves")
+	}
+
+	_, err := rr.ResolveProcess(&wasm.ResolveProcessRequest{})
+	if err != nil {
+		t.Fatalf("expected successful resolve after concurrent recovery, got: %v", err)
 	}
 }

--- a/openfeature-provider/go/confidence/internal/local_resolver/wasm.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/wasm.go
@@ -51,9 +51,14 @@ var _ LocalResolver = (*WasmResolver)(nil)
 // on the hot path.
 func (r *WasmResolver) exportedFunction(name string) api.Function {
 	if fn, ok := r.fnCache.Load(name); ok {
-		return fn.(api.Function)
+		if fn != nil {
+			return fn.(api.Function)
+		}
 	}
 	fn := r.instance.ExportedFunction(name)
+	if fn == nil {
+		panic(fmt.Errorf("WASM export %q unavailable (instance may be closed)", name))
+	}
 	r.fnCache.Store(name, fn)
 	return fn
 }

--- a/openfeature-provider/go/confidence/internal/local_resolver/wasm_memory_test.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/wasm_memory_test.go
@@ -65,3 +65,30 @@ func TestWasmMemoryStableOnRepeatedResolveCalls(t *testing.T) {
 			memBefore, memAfter, memAfter-memBefore, (memAfter-memBefore)/65536, iterations)
 	}
 }
+
+func TestWasmResolver_ExportedFunctionPanicsWhenExportMissing(t *testing.T) {
+	factory := NewWasmResolverFactory(NoOpLogSink)
+	defer factory.Close(context.Background())
+
+	resolver := factory.New().(*WasmResolver)
+
+	defer func() {
+		if rec := recover(); rec == nil {
+			t.Fatal("expected panic when WASM export is missing")
+		}
+	}()
+	_ = resolver.exportedFunction("wasm_msg_export_does_not_exist")
+}
+
+func TestWasmResolver_ExportedFunctionIgnoresCachedNil(t *testing.T) {
+	factory := NewWasmResolverFactory(NoOpLogSink)
+	defer factory.Close(context.Background())
+
+	resolver := factory.New().(*WasmResolver)
+	resolver.fnCache.Store("wasm_msg_alloc", nil)
+
+	fn := resolver.exportedFunction("wasm_msg_alloc")
+	if fn == nil {
+		t.Fatal("expected non-nil function after bypassing cached nil entry")
+	}
+}


### PR DESCRIPTION
## Summary
- Serialize `RecoveringResolver` operations with a mutex so WASM instance recreation cannot close an instance while another resolve is still running on it.
- Perform recreation synchronously while the mutex is held, instead of swapping/closing in a background goroutine during concurrent pool resolves.
- Never cache or return nil WASM export handles; panic with a descriptive error so `withRecover` turns follow-on failures into evaluation errors instead of silent process death.

## Motivation
When a WASM guest trap triggers recovery, the old wazero instance was closed in a background goroutine while another resolve on the same pooled slot could still be mid-call. `Module.ExportedFunction` on a closed instance returns nil, which was cached in `fnCache` and later dereferenced — producing exit code 139 with no Go traceback.

## Test plan
- [ ] `go test ./confidence/internal/local_resolver/... -run 'RecoveringResolver|ExportedFunction'`
- [ ] `go build ./...`
- [ ] Deploy alongside interpreter-mode fix or independently and monitor temporal-worker SIGSEGV rate

## Related
- Complements #514 (interpreter mode for SIGPROF/SIGURG during JIT execution)


Made with [Cursor](https://cursor.com)