### PR TITLE
fix(python): use UTC time in WASM host current_time callback

### DIFF
--- a/openfeature-provider/python/src/confidence/wasm_resolver.py
+++ b/openfeature-provider/python/src/confidence/wasm_resolver.py
@@ -5,7 +5,7 @@ Confidence flag resolver WASM module for local flag resolution.
 """
 
 import itertools
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from google.protobuf import message as protobuf_message
@@ -75,7 +75,7 @@ class WasmResolver:
 
         def current_time(ptr: int) -> int:
             self._consume_request(ptr)
-            now = datetime.now()
+            now = datetime.now(timezone.utc)
             timestamp = Timestamp()
             timestamp.FromDatetime(now)
             return self._transfer_response_success(timestamp.SerializeToString())


### PR DESCRIPTION
## Summary
- Fix `datetime.now()` → `datetime.now(timezone.utc)` in the Python provider's WASM host `current_time` callback
- `datetime.now()` returns naive local time, causing incorrect timestamps when the host timezone ≠ UTC
- All other providers (JS, Java, Go, Rust) already use UTC — this was the only one affected

## Test plan
- [x] Verified all other providers use UTC-correct time APIs
- [ ] CI passes (change is trivial — 2-line import + call fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)