### PR TITLE
fix: fix JS and Python publish failures

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -217,11 +217,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-      
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Publish to npm with OIDC
         run: npm publish ./artifacts/package.tgz --provenance --access public
@@ -338,6 +335,6 @@ jobs:
         run: ls -la ./artifacts/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           packages-dir: ./artifacts/


### PR DESCRIPTION
## Summary

Fixes the two publish failures from the v0.21.0 release run ([actions/runs/32232093189](https://github.com/spotify/confidence-resolver/actions/runs/32232093189)):

- **JS provider**: `npm install -g npm@latest` now pulls npm 12.x which requires Node ≥22.22.2, but the runner uses Node 20. Fix: bump `node-version` to `22` (LTS) and drop the `npm install -g npm@latest` step — Node 22 ships npm 10.x which already supports `--provenance`.

- **Python provider**: hatchling 1.32.0 now emits `Metadata-Version: 2.5` in wheel metadata. The pinned `pypa/gh-action-pypi-publish@v1.14.0` bundles Twine v6 which rejects metadata v2.5 as invalid. Fix: bump to `v1.14.2` which includes Twine v7 with metadata v2.5 support.

## Test plan

- [ ] CI passes on this PR (workflow syntax is valid)
- [ ] Re-run the failed publish jobs after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)