### PR TITLE
fix: pin npm for trusted publishing

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -220,6 +220,9 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Install npm with trusted publishing support
+        run: npm install -g npm@11.19.0
+
       - name: Publish to npm with OIDC
         run: npm publish ./artifacts/package.tgz --provenance --access public
 

--- a/openfeature-provider/js/.release-please-trigger
+++ b/openfeature-provider/js/.release-please-trigger
@@ -1,1 +1,1 @@
-Republish after the 0.18.0 registry upload failed.
+Republish after the 0.18.1 registry upload failed.


### PR DESCRIPTION
Pin npm 11.19.0 in the JS release job so OIDC trusted publishing works without pulling incompatible future major versions.

Update the JS release recovery marker after the failed 0.18.1 upload. Because this commit now touches openfeature-provider/js, Release Please should propose 0.18.2 after merge.

Validation: actionlint