### PR TITLE
fix: republish JS and Python providers

### DIFF
--- a/openfeature-provider/js/.release-please-trigger
+++ b/openfeature-provider/js/.release-please-trigger
@@ -1,0 +1,1 @@
+Republish after the 0.18.0 registry upload failed.

--- a/openfeature-provider/python/.release-please-trigger
+++ b/openfeature-provider/python/.release-please-trigger
@@ -1,0 +1,1 @@
+Republish after the 0.10.0 registry upload failed.


### PR DESCRIPTION
PR #519 only changed the root workflow, so Release Please found zero commits under the configured JS and Python package paths.

Add package-local recovery markers so merging this PR creates patch release candidates for JS 0.18.1 and Python 0.10.1. Publishing workflow fixes remain separate.