### PR TITLE
fix(openfeature-provider/java)!: rename disableApplyDedup builder method to enableApplyDedup

### DIFF
--- a/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/LocalProviderConfig.java
+++ b/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/LocalProviderConfig.java
@@ -162,10 +162,10 @@ public class LocalProviderConfig {
     }
 
     /**
-     * Disables apply-event deduplication in the WASM resolver. Dedup is enabled by default:
-     * repeated identical assignments within a short TTL window are logged once.
+     * Experimental: enables apply-event deduplication in the WASM resolver — repeated identical
+     * assignments within a short TTL window are logged once. Off by default; the API may change.
      */
-    public Builder disableApplyDedup(boolean enableApplyDedup) {
+    public Builder enableApplyDedup(boolean enableApplyDedup) {
       this.enableApplyDedup = enableApplyDedup;
       return this;
     }


### PR DESCRIPTION
## Summary

`LocalProviderConfig.Builder` shipped a method whose name says the opposite of what it does. In 0.18.0 (published today):

```java
/**
 * Disables apply-event deduplication in the WASM resolver. Dedup is enabled by default:
 * repeated identical assignments within a short TTL window are logged once.
 */
public Builder disableApplyDedup(boolean enableApplyDedup) {
  this.enableApplyDedup = enableApplyDedup;   // → isEnableApplyDedup() → proto enable_apply_dedup
  return this;
}
```

So `disableApplyDedup(true)` **enables** dedup, and the javadoc's "enabled by default" is stale — dedup is opt-in and off by default.

## Cause

The opt-in rename in #517 moved the parameter, field, and getter to `enableApplyDedup` but left the method name and javadoc on the old opt-out naming. It compiled cleanly, so nothing caught it.

Java was the only provider affected — Go (`WithEnableApplyDedup`), JS (`enableApplyDedup`), Python (`enable_apply_dedup`), and the proto (`enable_apply_dedup = 4`) were already correct.

## Change

Renames the method to `enableApplyDedup` and rewrites the javadoc to match the getter, the proto field, and the other providers.

```java
LocalProviderConfig.builder()
    .channelFactory(channelFactory)
    .enableApplyDedup(true)   // experimental, off by default
    .build();
```

## Breaking change

Breaking for anyone who adopted `disableApplyDedup` from 0.18.0, published today. No deprecation shim: the API is documented experimental, and keeping the old name alive would preserve a method that means the inverse of its behavior. Callers rename one method.

## Test plan
- [x] `mvn compile` clean
- [x] `fmt-maven-plugin:check` clean (57 files, 0 non-complying)
- [x] Verified no other references to the old name in any language or doc
- [x] No Rust/WASM sources touched, so the embedded WASM binary is unchanged and needs no re-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)