### PR TITLE
fix: enforce single provider init telemetry sample

### DIFF
--- a/openfeature-provider/go/confidence/provider_telemetry_resolver.go
+++ b/openfeature-provider/go/confidence/provider_telemetry_resolver.go
@@ -69,10 +69,9 @@ func (r *providerTelemetryResolver) addInitTelemetry(logs *resolverv1.WriteFlagL
 		logs.TelemetryData = &resolverv1.TelemetryData{}
 	}
 	logs.TelemetryData.Sdk = r.sdk
-	logs.TelemetryData.ProviderInitRate = append(
-		logs.TelemetryData.ProviderInitRate,
-		&resolverv1.TelemetryData_ProviderInitRate{Count: 1, Labels: r.labels},
-	)
+	logs.TelemetryData.ProviderInitRate = []*resolverv1.TelemetryData_ProviderInitRate{
+		{Count: 1, Labels: r.labels},
+	}
 }
 
 func (r *providerTelemetryResolver) SetResolverState(request *wasm.SetResolverStateRequest) error {

--- a/openfeature-provider/go/confidence/provider_telemetry_resolver_test.go
+++ b/openfeature-provider/go/confidence/provider_telemetry_resolver_test.go
@@ -51,6 +51,30 @@ func TestProviderTelemetryResolverCloseEmitsWithoutResolve(t *testing.T) {
 	}
 }
 
+func TestProviderTelemetryResolverOwnsSingleInitSample(t *testing.T) {
+	resolver := &providerTelemetryResolver{
+		labels: map[string]string{"encryption": "true"},
+		sdk:    &resolvertypes.Sdk{Version: "test-version"},
+	}
+	logs := &resolverv1.WriteFlagLogsRequest{
+		TelemetryData: &resolverv1.TelemetryData{
+			ProviderInitRate: []*resolverv1.TelemetryData_ProviderInitRate{
+				{Count: 1, Labels: map[string]string{"existing": "true"}},
+			},
+		},
+	}
+
+	resolver.addInitTelemetry(logs)
+
+	got := logs.GetTelemetryData().GetProviderInitRate()
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one provider init sample, got %d", len(got))
+	}
+	if got[0].GetLabels()["encryption"] != "true" {
+		t.Fatalf("expected provider-owned labels, got %v", got[0].GetLabels())
+	}
+}
+
 func TestProviderTelemetryResolverRetriesAfterSinkFailure(t *testing.T) {
 	attempts := 0
 	var captured []*resolverv1.WriteFlagLogsRequest

--- a/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/ProviderTelemetryResolver.java
+++ b/openfeature-provider/java/src/main/java/com/spotify/confidence/sdk/ProviderTelemetryResolver.java
@@ -50,6 +50,7 @@ final class ProviderTelemetryResolver implements LocalResolver {
         .setTelemetryData(
             request.getTelemetryData().toBuilder()
                 .setSdk(sdk)
+                .clearProviderInitRate()
                 .addProviderInitRate(
                     TelemetryData.ProviderInitRate.newBuilder()
                         .setCount(1)

--- a/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/ProviderTelemetryResolverTest.java
+++ b/openfeature-provider/java/src/test/java/com/spotify/confidence/sdk/ProviderTelemetryResolverTest.java
@@ -9,6 +9,7 @@ import com.spotify.confidence.sdk.flags.resolver.v1.ResolveProcessRequest;
 import com.spotify.confidence.sdk.flags.resolver.v1.ResolveProcessResponse;
 import com.spotify.confidence.sdk.flags.resolver.v1.Sdk;
 import com.spotify.confidence.sdk.flags.resolver.v1.SdkId;
+import com.spotify.confidence.sdk.flags.resolver.v1.TelemetryData;
 import com.spotify.confidence.sdk.flags.resolver.v1.WriteFlagLogsRequest;
 import java.util.ArrayList;
 import java.util.Map;
@@ -53,6 +54,32 @@ class ProviderTelemetryResolverTest {
   }
 
   @Test
+  void ownsSingleInitSample() {
+    final var captured = new ArrayList<WriteFlagLogsRequest>();
+    final var existingRequest =
+        WriteFlagLogsRequest.newBuilder()
+            .setTelemetryData(
+                TelemetryData.newBuilder()
+                    .addProviderInitRate(
+                        TelemetryData.ProviderInitRate.newBuilder()
+                            .setCount(1)
+                            .putLabels("existing", "true")))
+            .build();
+    final var resolver =
+        new ProviderTelemetryResolver(
+            captured::add,
+            SDK,
+            Map.of("encryption", "true"),
+            sink -> new TelemetryTestResolver(sink, 1, existingRequest));
+
+    resolver.flushAllLogs();
+
+    assertThat(captured.get(0).getTelemetryData().getProviderInitRateList())
+        .singleElement()
+        .satisfies(sample -> assertThat(sample.getLabelsMap()).containsOnlyKeys("encryption"));
+  }
+
+  @Test
   void retriesAfterSinkFailure() {
     final var attempts = new AtomicInteger();
     final var captured = new ArrayList<WriteFlagLogsRequest>();
@@ -83,10 +110,17 @@ class ProviderTelemetryResolverTest {
   private static final class TelemetryTestResolver implements LocalResolver {
     private final Consumer<WriteFlagLogsRequest> sink;
     private final int flushCount;
+    private final WriteFlagLogsRequest request;
 
     private TelemetryTestResolver(Consumer<WriteFlagLogsRequest> sink, int flushCount) {
+      this(sink, flushCount, WriteFlagLogsRequest.getDefaultInstance());
+    }
+
+    private TelemetryTestResolver(
+        Consumer<WriteFlagLogsRequest> sink, int flushCount, WriteFlagLogsRequest request) {
       this.sink = sink;
       this.flushCount = flushCount;
+      this.request = request;
     }
 
     @Override
@@ -106,7 +140,7 @@ class ProviderTelemetryResolverTest {
     @Override
     public void flushAllLogs() {
       for (int i = 0; i < flushCount; i++) {
-        sink.accept(WriteFlagLogsRequest.getDefaultInstance());
+        sink.accept(request);
       }
     }
 

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.test.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.test.ts
@@ -170,7 +170,7 @@ describe('flush behavior', () => {
           telemetryData: {
             resolverVersion: '0.20.0',
             sdk: { id: 25, version: 'resolver-version' },
-            providerInitRate: [{ count: 2, labels: { existing: 'true' } }],
+            providerInitRate: [{ count: 1, labels: { existing: 'true' } }],
           },
         }),
       ).finish(),
@@ -182,10 +182,7 @@ describe('flush behavior', () => {
     const decoded = WriteFlagLogsRequest.decode(sentBody!);
     expect(decoded.telemetryData?.resolverVersion).toBe('0.20.0');
     expect(decoded.telemetryData?.sdk).toEqual({ id: 22, customId: undefined, version: VERSION });
-    expect(decoded.telemetryData?.providerInitRate).toEqual([
-      { count: 2, labels: { existing: 'true' } },
-      { count: 1, labels: { encryption: 'false' } },
-    ]);
+    expect(decoded.telemetryData?.providerInitRate).toEqual([{ count: 1, labels: { encryption: 'false' } }]);
   });
 
   it('does not retry provider init telemetry after an HTTP failure', async () => {

--- a/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
+++ b/openfeature-provider/js/src/ConfidenceServerProviderLocal.ts
@@ -458,7 +458,7 @@ export class ConfidenceServerProviderLocal implements Provider {
       id: SdkId.SDK_ID_JS_LOCAL_SERVER_PROVIDER,
       version: VERSION,
     };
-    request.telemetryData.providerInitRate.push({ count: 1, labels: this.initLabels });
+    request.telemetryData.providerInitRate = [{ count: 1, labels: this.initLabels }];
     return WriteFlagLogsRequest.encode(request).finish();
   }
 

--- a/openfeature-provider/python/src/confidence/provider.py
+++ b/openfeature-provider/python/src/confidence/provider.py
@@ -795,6 +795,7 @@ class ConfidenceProvider(AbstractProvider):
                     version=__version__,
                 )
             )
+            request.telemetry_data.ClearField("provider_init_rate")
             init_rate = request.telemetry_data.provider_init_rate.add()
             init_rate.count = 1
             for k, v in self._init_labels.items():

--- a/openfeature-provider/python/tests/test_provider.py
+++ b/openfeature-provider/python/tests/test_provider.py
@@ -50,6 +50,9 @@ class TestInitialize:
         )
         request = internal_api_pb2.WriteFlagLogsRequest()
         request.telemetry_data.SetInParent()
+        existing = request.telemetry_data.provider_init_rate.add()
+        existing.count = 1
+        existing.labels["existing"] = "true"
 
         provider._write_logs(request.SerializeToString())
         decoded = internal_api_pb2.WriteFlagLogsRequest.FromString(
@@ -59,6 +62,9 @@ class TestInitialize:
         assert decoded.telemetry_data.sdk.id == types_pb2.SdkId.SDK_ID_PYTHON_PROVIDER
         assert decoded.telemetry_data.sdk.version == __version__
         assert len(decoded.telemetry_data.provider_init_rate) == 1
+        assert dict(decoded.telemetry_data.provider_init_rate[0].labels) == {
+            "encryption": "false"
+        }
 
     def test_init_telemetry_retries_after_failed_write(
         self,

--- a/openfeature-provider/rust/src/logger.rs
+++ b/openfeature-provider/rust/src/logger.rs
@@ -10,7 +10,7 @@ use tokio::sync::RwLock;
 
 use confidence_resolver::assign_logger::AssignLogger;
 use confidence_resolver::proto::confidence::flags::resolver::v1::{
-    telemetry_data::ProviderInitRate, Sdk, WriteFlagLogsRequest,
+    telemetry_data::ProviderInitRate, Sdk, TelemetryData, WriteFlagLogsRequest,
 };
 use confidence_resolver::resolve_logger::ResolveLogger;
 
@@ -224,10 +224,7 @@ impl LogManager {
         td.sdk = Some(self.sdk.clone());
         let include_init = self.init_state.claim();
         if include_init {
-            td.provider_init_rate.push(ProviderInitRate {
-                count: 1,
-                labels: self.init_labels.clone(),
-            });
+            set_provider_init_telemetry(&mut td, &self.init_labels);
         }
         request.telemetry_data = Some(td);
 
@@ -260,6 +257,13 @@ impl LogManager {
     }
 }
 
+fn set_provider_init_telemetry(telemetry: &mut TelemetryData, labels: &BTreeMap<String, String>) {
+    telemetry.provider_init_rate = vec![ProviderInitRate {
+        count: 1,
+        labels: labels.clone(),
+    }];
+}
+
 /// Check if a WriteFlagLogsRequest has any logs to send.
 fn has_logs(request: &WriteFlagLogsRequest) -> bool {
     !request.flag_assigned.is_empty()
@@ -271,6 +275,23 @@ fn has_logs(request: &WriteFlagLogsRequest) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn provider_owns_single_init_sample() {
+        let mut telemetry = TelemetryData {
+            provider_init_rate: vec![ProviderInitRate {
+                count: 1,
+                labels: BTreeMap::from([("existing".to_string(), "true".to_string())]),
+            }],
+            ..Default::default()
+        };
+        let labels = BTreeMap::from([("encryption".to_string(), "true".to_string())]);
+
+        set_provider_init_telemetry(&mut telemetry, &labels);
+
+        assert_eq!(telemetry.provider_init_rate.len(), 1);
+        assert_eq!(telemetry.provider_init_rate[0].labels, labels);
+    }
 
     #[test]
     fn test_encode_ingest_request_roundtrip() {


### PR DESCRIPTION
## Context

#485 introduced `provider_init_rate` telemetry for the local providers. The provider wrapper is the sole owner of this metric: one provider instance should emit exactly one sample, with `count = 1`, on its first successful telemetry write.

The initial implementation appended that sample to the repeated protobuf field. That happened to work when the resolver returned an empty `provider_init_rate`, but it encoded the wrong merge behavior: any unexpected or stale samples from a lower-level resolver would be retained, producing multiple provider-init samples in one request. The JS test also codified that behavior by expecting the existing sample to survive.

Counts greater than one should only appear after the telemetry backend aggregates samples from multiple provider initializations. A provider should never send a single wire sample with an accumulated count, nor combine its sample with samples supplied by a lower layer.

## Change

Make the provider layer replace `provider_init_rate` with a singleton sample instead of appending to it in the JS, Java, Go, Python, and Rust local providers:

```text
provider_init_rate = [{ count: 1, labels: <provider init labels> }]
```

Other telemetry metadata in the request, including resolver version and SDK information, is still preserved or populated as before. The existing once-only and retry behavior is unchanged; this only makes ownership of the field explicit when the first sample is attached.

Each provider now has regression coverage that starts with an existing provider-init sample and verifies that it is replaced by exactly one provider-owned sample.

## Validation

- Go provider telemetry tests and Docker lint/test target
- Java `ProviderTelemetryResolverTest` and Spotify Java formatter
- JS provider tests, typecheck, and Prettier validation
- Python provider tests and Docker lint/test targets (90 tests)
- Rust logger tests and formatting
