### PR TITLE
docs: clarify exposure collection changelog entry

### DIFF
--- a/confidence-resolver/CHANGELOG.md
+++ b/confidence-resolver/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Features
 
-* disable exposure collection on local OpenFeature providers ([#527](https://github.com/spotify/confidence-resolver/issues/527)) ([4b3ef41](https://github.com/spotify/confidence-resolver/commit/4b3ef418223c4a4155fa028672710df307057ce0))
+* add option to disable exposure collection on local OpenFeature providers ([#527](https://github.com/spotify/confidence-resolver/issues/527)) ([4b3ef41](https://github.com/spotify/confidence-resolver/commit/4b3ef418223c4a4155fa028672710df307057ce0))
 * flag apply event deduplication in core resolver and WASM guest ([#517](https://github.com/spotify/confidence-resolver/issues/517)) ([47c5735](https://github.com/spotify/confidence-resolver/commit/47c5735c10b6402ea106328ecc031376000740bb))
 
 ## [0.21.0](https://github.com/spotify/confidence-resolver/compare/confidence_resolver-v0.20.0...confidence_resolver-v0.21.0) (2026-08-18)

--- a/openfeature-provider/go/CHANGELOG.md
+++ b/openfeature-provider/go/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Features
 
-* disable exposure collection on local OpenFeature providers ([#527](https://github.com/spotify/confidence-resolver/issues/527)) ([4b3ef41](https://github.com/spotify/confidence-resolver/commit/4b3ef418223c4a4155fa028672710df307057ce0))
+* add option to disable exposure collection on local OpenFeature providers ([#527](https://github.com/spotify/confidence-resolver/issues/527)) ([4b3ef41](https://github.com/spotify/confidence-resolver/commit/4b3ef418223c4a4155fa028672710df307057ce0))
 * flag apply event deduplication in core resolver and WASM guest ([#517](https://github.com/spotify/confidence-resolver/issues/517)) ([47c5735](https://github.com/spotify/confidence-resolver/commit/47c5735c10b6402ea106328ecc031376000740bb))
 
 

--- a/openfeature-provider/java/CHANGELOG.md
+++ b/openfeature-provider/java/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### Features
 
-* disable exposure collection on local OpenFeature providers ([#527](https://github.com/spotify/confidence-resolver/issues/527)) ([4b3ef41](https://github.com/spotify/confidence-resolver/commit/4b3ef418223c4a4155fa028672710df307057ce0))
+* add option to disable exposure collection on local OpenFeature providers ([#527](https://github.com/spotify/confidence-resolver/issues/527)) ([4b3ef41](https://github.com/spotify/confidence-resolver/commit/4b3ef418223c4a4155fa028672710df307057ce0))
 * flag apply event deduplication in core resolver and WASM guest ([#517](https://github.com/spotify/confidence-resolver/issues/517)) ([47c5735](https://github.com/spotify/confidence-resolver/commit/47c5735c10b6402ea106328ecc031376000740bb))
 
 

--- a/openfeature-provider/js/CHANGELOG.md
+++ b/openfeature-provider/js/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Features
 
-* disable exposure collection on local OpenFeature providers ([#527](https://github.com/spotify/confidence-resolver/issues/527)) ([4b3ef41](https://github.com/spotify/confidence-resolver/commit/4b3ef418223c4a4155fa028672710df307057ce0))
+* add option to disable exposure collection on local OpenFeature providers ([#527](https://github.com/spotify/confidence-resolver/issues/527)) ([4b3ef41](https://github.com/spotify/confidence-resolver/commit/4b3ef418223c4a4155fa028672710df307057ce0))
 * flag apply event deduplication in core resolver and WASM guest ([#517](https://github.com/spotify/confidence-resolver/issues/517)) ([47c5735](https://github.com/spotify/confidence-resolver/commit/47c5735c10b6402ea106328ecc031376000740bb))
 
 

--- a/openfeature-provider/python/CHANGELOG.md
+++ b/openfeature-provider/python/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Features
 
-* disable exposure collection on local OpenFeature providers ([#527](https://github.com/spotify/confidence-resolver/issues/527)) ([4b3ef41](https://github.com/spotify/confidence-resolver/commit/4b3ef418223c4a4155fa028672710df307057ce0))
+* add option to disable exposure collection on local OpenFeature providers ([#527](https://github.com/spotify/confidence-resolver/issues/527)) ([4b3ef41](https://github.com/spotify/confidence-resolver/commit/4b3ef418223c4a4155fa028672710df307057ce0))
 * flag apply event deduplication in core resolver and WASM guest ([#517](https://github.com/spotify/confidence-resolver/issues/517)) ([47c5735](https://github.com/spotify/confidence-resolver/commit/47c5735c10b6402ea106328ecc031376000740bb))
 
 

--- a/openfeature-provider/rust/CHANGELOG.md
+++ b/openfeature-provider/rust/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Features
 
-* disable exposure collection on local OpenFeature providers ([#527](https://github.com/spotify/confidence-resolver/issues/527)) ([4b3ef41](https://github.com/spotify/confidence-resolver/commit/4b3ef418223c4a4155fa028672710df307057ce0))
+* add option to disable exposure collection on local OpenFeature providers ([#527](https://github.com/spotify/confidence-resolver/issues/527)) ([4b3ef41](https://github.com/spotify/confidence-resolver/commit/4b3ef418223c4a4155fa028672710df307057ce0))
 
 
 ### Dependencies

--- a/wasm/rust-guest/CHANGELOG.md
+++ b/wasm/rust-guest/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Features
 
-* disable exposure collection on local OpenFeature providers ([#527](https://github.com/spotify/confidence-resolver/issues/527)) ([4b3ef41](https://github.com/spotify/confidence-resolver/commit/4b3ef418223c4a4155fa028672710df307057ce0))
+* add option to disable exposure collection on local OpenFeature providers ([#527](https://github.com/spotify/confidence-resolver/issues/527)) ([4b3ef41](https://github.com/spotify/confidence-resolver/commit/4b3ef418223c4a4155fa028672710df307057ce0))
 * flag apply event deduplication in core resolver and WASM guest ([#517](https://github.com/spotify/confidence-resolver/issues/517)) ([47c5735](https://github.com/spotify/confidence-resolver/commit/47c5735c10b6402ea106328ecc031376000740bb))
 
 


### PR DESCRIPTION
Clarifies that local OpenFeature providers gained the option to disable exposure collection; exposure collection was not disabled by default.

Tests not run (documentation-only change).