### PR TITLE
build: bump Node.js to 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -340,7 +340,7 @@ CMD ["./confidence-cloudflare-resolver/deployer/script.sh"]
 # ==============================================================================
 # OpenFeature Provider (TypeScript) - Build and test
 # ==============================================================================
-FROM node:20-alpine AS openfeature-provider-js-base
+FROM node:22-alpine AS openfeature-provider-js-base
 
 # Install protoc for proto generation
 RUN apk add --no-cache protobuf-dev protoc make

--- a/openfeature-provider/js/bench/Dockerfile
+++ b/openfeature-provider/js/bench/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine3.22
+FROM node:22-alpine3.22
 
 WORKDIR /app
 
@@ -15,5 +15,4 @@ COPY openfeature-provider/js/bench ./bench
 ENV NODE_ENV=production
 
 ENTRYPOINT ["node", "bench/bench.mjs"]
-
 


### PR DESCRIPTION
## Summary
- bump the main JS build image to Node.js 22
- bump the JS benchmark image to Node.js 22

## Validation
- full `docker build .` with BuildKit secrets