### PR TITLE
build(go)!: require Go 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -453,7 +453,7 @@ COPY --from=openfeature-provider-js.pack /app/package.tgz /package.tgz
 # ==============================================================================
 # OpenFeature Provider (Go) - Build and test
 # ==============================================================================
-FROM golang:1.24-alpine AS openfeature-provider-go-base
+FROM golang:1.25-alpine AS openfeature-provider-go-base
 
 # Install make (needed for Makefile targets)
 RUN apk add --no-cache make

--- a/mock-support-server/Dockerfile
+++ b/mock-support-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine3.22 AS build
+FROM golang:1.25-alpine3.22 AS build
 WORKDIR /src/mock-support-server
 
 # Copy module files and download dependencies (cached)
@@ -24,5 +24,4 @@ COPY data/resolver_state_current.pb /data/resolver_state_current.pb
 ENV PORT=8081
 EXPOSE 8081
 ENTRYPOINT ["/mock-support-server"]
-
 

--- a/openfeature-provider/go/README.md
+++ b/openfeature-provider/go/README.md
@@ -21,7 +21,7 @@ go mod tidy
 
 ## Requirements
 
-- Go 1.24+
+- Go 1.25+
 - OpenFeature Go SDK 1.16.0+
 
 > **Note:** Use v0.20.1 or later; the v0.20.0 tag shipped with an out-of-sync embedded WASM module.

--- a/openfeature-provider/go/demo/README.md
+++ b/openfeature-provider/go/demo/README.md
@@ -4,7 +4,7 @@ Demo application showing how to use the Confidence OpenFeature Local Provider in
 
 ## Prerequisites
 
-- Go 1.24+
+- Go 1.25+
 - Confidence API credentials
 
 ## Setup

--- a/openfeature-provider/go/go.mod
+++ b/openfeature-provider/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/spotify/confidence-resolver/openfeature-provider/go
 
-go 1.24.0
+go 1.25.0
 
 require github.com/open-feature/go-sdk v1.16.0
 


### PR DESCRIPTION
## Summary

- require Go 1.25 for the Go provider
- align the provider and mock-server build images on Go 1.25
- update the documented minimum Go version

## Breaking change

The Go provider now requires Go 1.25 or newer. Consumers using an older toolchain must upgrade or use automatic toolchain switching.

## Testing

- full Docker build, including tests, linters, E2E suites, and WASM sync validation