### PR TITLE
ci: upgrade release please action to v5

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Release Please (manifest)
         id: releasemanifest
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json


### PR DESCRIPTION
## Summary
- upgrade release-please-action from v4 to v5
- use the Node.js 24 action runtime

## Validation
- verified the action inputs and outputs are unchanged
- verified the release configuration remains compatible
- ran git diff --check