### PR TITLE
chore: group Go security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,9 @@ updates:
     schedule:
       interval: "monthly"
     groups:
+      go-security-updates:
+        applies-to: "security-updates"
+        patterns: ["*"]
       go-minor-and-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]


### PR DESCRIPTION
## Summary

- group Go security updates across all four module directories
- keep monthly version-update grouping unchanged
- preserve immediate Dependabot security remediation

## Validation

- parsed and asserted the Go Dependabot configuration with Ruby YAML
- `git diff --check`