### PR TITLE
fix(go): fail e2e tests without credentials

### DIFF
--- a/openfeature-provider/go/confidence/e2e_test.go
+++ b/openfeature-provider/go/confidence/e2e_test.go
@@ -18,10 +18,15 @@ const (
 	e2eExcludedTargetingKey = "user-x"
 )
 
-func TestFlagResolve_WithMaterializedSegmentTargetingAndRemoteMaterializationStore(t *testing.T) {
-	if e2eClientSecret == "" {
-		t.Skip("CONFIDENCE_CLIENT_SECRET not set")
+func requireE2EEnvironmentVariable(t *testing.T, name, value string) {
+	t.Helper()
+	if value == "" {
+		t.Fatalf("%s must be set to run e2e tests", name)
 	}
+}
+
+func TestFlagResolve_WithMaterializedSegmentTargetingAndRemoteMaterializationStore(t *testing.T) {
+	requireE2EEnvironmentVariable(t, "CONFIDENCE_CLIENT_SECRET", e2eClientSecret)
 	ctx := context.Background()
 
 	// Create a real provider with a RemoteMaterializationStore
@@ -56,9 +61,7 @@ func TestFlagResolve_WithMaterializedSegmentTargetingAndRemoteMaterializationSto
 }
 
 func TestFlagResolve_WithMaterializedSegmentTargetingAndRemoteMaterializationStoreNotInSegment(t *testing.T) {
-	if e2eClientSecret == "" {
-		t.Skip("CONFIDENCE_CLIENT_SECRET not set")
-	}
+	requireE2EEnvironmentVariable(t, "CONFIDENCE_CLIENT_SECRET", e2eClientSecret)
 	ctx := context.Background()
 
 	// Create a real provider with a RemoteMaterializationStore
@@ -93,9 +96,7 @@ func TestFlagResolve_WithMaterializedSegmentTargetingAndRemoteMaterializationSto
 }
 
 func TestFlagResolve_WithMaterializedSegmentTargetingAndNoMaterializationStoreUsesBloomFilter(t *testing.T) {
-	if e2eClientSecret == "" {
-		t.Skip("CONFIDENCE_CLIENT_SECRET not set")
-	}
+	requireE2EEnvironmentVariable(t, "CONFIDENCE_CLIENT_SECRET", e2eClientSecret)
 	ctx := context.Background()
 
 	// Without a materialization store, the resolver uses bloom filters
@@ -129,9 +130,8 @@ func TestFlagResolve_WithMaterializedSegmentTargetingAndNoMaterializationStoreUs
 }
 
 func TestFlagResolve_WithEncryptedState(t *testing.T) {
-	if e2eClientSecret == "" {
-		t.Skip("CONFIDENCE_CLIENT_SECRET not set")
-	}
+	requireE2EEnvironmentVariable(t, "CONFIDENCE_CLIENT_SECRET", e2eClientSecret)
+	requireE2EEnvironmentVariable(t, "CONFIDENCE_CLIENT_ENCRYPTION_KEY", e2eEncryptionKey)
 	ctx := context.Background()
 	provider, err := NewProvider(ctx, ProviderConfig{
 		ClientSecret:  e2eClientSecret,

--- a/openfeature-provider/go/confidence/flag_logger_e2e_test.go
+++ b/openfeature-provider/go/confidence/flag_logger_e2e_test.go
@@ -22,9 +22,7 @@ const flagLogsTargetingKey = "test-a"
 // send WriteFlagLogs to the real Confidence backend and get a successful response.
 // This uses the real gRPC connection to edge-grpc.spotify.com.
 func TestFlagLogs_ShouldSuccessfullySendToRealBackend(t *testing.T) {
-	if flagLogsClientSecret == "" {
-		t.Skip("CONFIDENCE_CLIENT_SECRET not set")
-	}
+	requireE2EEnvironmentVariable(t, "CONFIDENCE_CLIENT_SECRET", flagLogsClientSecret)
 	ctx := context.Background()
 
 	// Create a custom logger that captures log messages (Debug level to capture all logs)

--- a/openfeature-provider/go/confidence/flag_logs_test.go
+++ b/openfeature-provider/go/confidence/flag_logs_test.go
@@ -31,9 +31,7 @@ const unitTestTargetingKey = "test-a"
 // Returns the capturing logger, provider, and client.
 // The caller is responsible for calling openfeature.Shutdown() when done.
 func setupFlagLogsUnitTest(t *testing.T) (*fl.CapturingFlagLogger, openfeature.IClient) {
-	if unitTestClientSecret == "" {
-		t.Skip("CONFIDENCE_CLIENT_SECRET not set")
-	}
+	requireE2EEnvironmentVariable(t, "CONFIDENCE_CLIENT_SECRET", unitTestClientSecret)
 	ctx := context.Background()
 
 	// Create capturing logger


### PR DESCRIPTION
Fails Go e2e tests when required credentials are absent instead of skipping them. Also validates the encryption key for encrypted-state coverage.

Tests: `go test ./confidence -run "^$"`; verified missing credentials fail focused e2e tests.