### PR TITLE
feat(go): add WithApplyTime to backdate exposure events

### DIFF
--- a/openfeature-provider/go/README.md
+++ b/openfeature-provider/go/README.md
@@ -623,10 +623,20 @@ value, err := client.BooleanValue(ctx, "my-flag.enabled", false, evalCtx)
 
 The key is automatically stripped from the context before it reaches the resolver.
 
+To record the exposure at a different time than the resolve, wrap the context with `WithApplyTime`:
+
+```go
+ctx = confidence.WithApplyTime(ctx, messageArrivalTime)
+value, err := client.BooleanValue(ctx, "my-flag.enabled", false, evalCtx)
+```
+
+Use this when the treatment applies to something timestamped before the resolve, e.g. a server resolving a flag while handling a message: facts derived from the message carry its arrival time, so an exposure stamped at resolve time lands after them and the first treated message counts as pre-exposure in analysis.
+
 | Mechanism | Scope | Assignment/exposure events | Resolve logs and telemetry |
 | --- | --- | --- | --- |
 | `DisableExposureCollection` provider config | All OpenFeature evaluations through this provider | Never queued; no deferred apply token is returned | Still sent |
 | `_confidence_skip_apply` context key | One evaluation | No immediate exposure event for that evaluation | Still sent |
+| `WithApplyTime` context | Evaluations made with that context | Recorded with the provided timestamp instead of the resolve time | Still sent |
 
 This is an advanced feature intended for exceptional cases. If you're considering using it, reach out to the Confidence team to discuss the best approach for your setup.
 

--- a/openfeature-provider/go/confidence/apply_time.go
+++ b/openfeature-provider/go/confidence/apply_time.go
@@ -1,0 +1,55 @@
+package confidence
+
+import (
+	"context"
+	"time"
+
+	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolver"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type applyTimeKey struct{}
+
+// WithApplyTime returns a context whose flag evaluations record their exposure
+// at t instead of the resolve time. Use it when the treatment applies to
+// something timestamped before the resolve, such as a message whose handling
+// triggered the evaluation. `_confidence_skip_apply` and
+// DisableExposureCollection take precedence.
+func WithApplyTime(ctx context.Context, t time.Time) context.Context {
+	return context.WithValue(ctx, applyTimeKey{}, t)
+}
+
+func applyTimeFromContext(ctx context.Context) (time.Time, bool) {
+	t, ok := ctx.Value(applyTimeKey{}).(time.Time)
+	return t, ok
+}
+
+// applyWithTime records exposure events for the resolved flags, stamped with
+// the given apply time instead of the resolve time. The resolve must have been
+// made with apply=false so the response carries a resolve token.
+func (p *LocalResolverProvider) applyWithTime(flagName string, response *resolver.ResolveFlagsResponse, applyTime time.Time) {
+	ts := timestamppb.New(applyTime)
+	flags := make([]*resolver.AppliedFlag, 0, len(response.GetResolvedFlags()))
+	for _, rf := range response.GetResolvedFlags() {
+		if !rf.GetShouldApply() {
+			continue
+		}
+		flags = append(flags, &resolver.AppliedFlag{Flag: rf.GetFlag(), ApplyTime: ts})
+	}
+	if len(flags) == 0 {
+		return
+	}
+	request := &resolver.ApplyFlagsRequest{
+		Flags:        flags,
+		ClientSecret: p.clientSecret,
+		ResolveToken: response.GetResolveToken(),
+		SendTime:     timestamppb.Now(),
+		Sdk: &resolver.Sdk{
+			Sdk:     &resolver.Sdk_Id{Id: resolver.SdkId_SDK_ID_GO_LOCAL_PROVIDER},
+			Version: Version,
+		},
+	}
+	if err := p.resolver.ApplyFlags(request); err != nil {
+		p.logger.Error("Failed to apply flag with backdated apply time", "flag", flagName, "error", err)
+	}
+}

--- a/openfeature-provider/go/confidence/internal/testutil/helpers.go
+++ b/openfeature-provider/go/confidence/internal/testutil/helpers.go
@@ -437,6 +437,7 @@ type MockedLocalResolver struct {
 	Err                  error
 	LastRequest          *wasm.ResolveProcessRequest
 	LastSetResolverState *wasm.SetResolverStateRequest
+	LastApplyRequest     *resolver.ApplyFlagsRequest
 	// Sequenced responses support
 	Responses []*wasm.ResolveProcessResponse
 	callIdx   int
@@ -464,7 +465,10 @@ func (m *MockedLocalResolver) SetResolverState(req *wasm.SetResolverStateRequest
 }
 func (m MockedLocalResolver) PrometheusSnapshot(_ uint32, _ bool) string   { return "" }
 func (m MockedLocalResolver) RegisterResolve(*wasm.RegisterResolveRequest) {}
-func (m MockedLocalResolver) ApplyFlags(*resolver.ApplyFlagsRequest) error { return nil }
+func (m *MockedLocalResolver) ApplyFlags(req *resolver.ApplyFlagsRequest) error {
+	m.LastApplyRequest = req
+	return nil
+}
 
 func MustJSONToProto(jsonString string) *structpb.Value {
 	var v structpb.Value

--- a/openfeature-provider/go/confidence/provider.go
+++ b/openfeature-provider/go/confidence/provider.go
@@ -359,10 +359,11 @@ func evaluate[T any](
 		})
 	}
 
-	// apply=false covers both provider DisableExposureCollection and per-eval
-	// `_confidence_skip_apply`. Provider DisableExposureCollection is also forwarded on
-	// setResolverState so the guest skips assign/token entirely; apply=false
-	// alone would still mint a deferred token.
+	// apply=false on the resolve covers provider DisableExposureCollection, per-eval
+	// `_confidence_skip_apply`, and WithApplyTime (which applies afterwards with the
+	// resolve token). Provider DisableExposureCollection is also forwarded on
+	// setResolverState so the guest skips assign/token entirely; apply=false alone
+	// would still mint a deferred token.
 	apply := !p.disableExposureCollection
 	if skip, ok := evalCtx["_confidence_skip_apply"]; ok {
 		if b, ok := skip.(bool); ok && b {
@@ -370,8 +371,9 @@ func evaluate[T any](
 		}
 		delete(evalCtx, "_confidence_skip_apply")
 	}
+	applyTime, backdateApply := applyTimeFromContext(ctx)
 
-	response, err := p.resolveFlags(evalCtx, []string{requestFlagName}, apply)
+	response, err := p.resolveFlags(evalCtx, []string{requestFlagName}, apply && !backdateApply)
 	if err != nil {
 		var matErr *MaterializationNotSupportedError
 		if errors.As(err, &matErr) {
@@ -398,6 +400,10 @@ func evaluate[T any](
 				ResolutionError: openfeature.NewGeneralResolutionError(err.Error()),
 			},
 		}
+	}
+
+	if apply && backdateApply {
+		p.applyWithTime(flagName, response, applyTime)
 	}
 
 	if len(response.ResolvedFlags) == 0 {

--- a/openfeature-provider/go/confidence/provider_resolve_test.go
+++ b/openfeature-provider/go/confidence/provider_resolve_test.go
@@ -5,14 +5,17 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/open-feature/go-sdk/openfeature"
 	lr "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/local_resolver"
 	adminv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/admin"
 	iamv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/admin"
+	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolver"
 	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/wasm"
 	tu "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/testutil"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestLocalResolverProvider_ReturnsDefaultOnError(t *testing.T) {
@@ -402,6 +405,141 @@ func TestLocalResolverProvider_MissingMaterializations(t *testing.T) {
 
 		if result.Reason != openfeature.ErrorReason {
 			t.Errorf("Expected ErrorReason when materializations missing, got %v", result.Reason)
+		}
+	})
+}
+
+func TestLocalResolverProvider_WithApplyTime(t *testing.T) {
+	applyTime := time.Date(2026, 7, 29, 11, 0, 0, 0, time.UTC)
+	ctx := WithApplyTime(context.Background(), applyTime)
+
+	response := func(shouldApply bool) *resolver.ResolveFlagsResponse {
+		return &resolver.ResolveFlagsResponse{
+			ResolvedFlags: []*resolver.ResolvedFlag{{
+				Flag:    "flags/tutorial-feature",
+				Variant: "flags/tutorial-feature/variants/on",
+				Value: &structpb.Struct{Fields: map[string]*structpb.Value{
+					"enabled": structpb.NewBoolValue(true),
+				}},
+				ShouldApply: shouldApply,
+			}},
+			ResolveToken: []byte("test-resolve-token"),
+			ResolveId:    "test-resolve-id",
+		}
+	}
+
+	setup := func(t *testing.T, resp *resolver.ResolveFlagsResponse, opts ...Option) (*tu.MockedLocalResolver, *openfeature.Client) {
+		t.Helper()
+		mockedResolver := &tu.MockedLocalResolver{
+			Response: &wasm.ResolveProcessResponse{
+				Result: &wasm.ResolveProcessResponse_Resolved_{
+					Resolved: &wasm.ResolveProcessResponse_Resolved{Response: resp},
+				},
+			},
+		}
+		stateProvider := &tu.StateProviderMock{
+			State:     tu.LoadTestResolverState(t),
+			AccountID: tu.LoadTestAccountID(t),
+		}
+		resolverSupplier := wrapResolverSupplierWithMaterializations(func(ctx context.Context, logSink lr.LogSink) lr.LocalResolver {
+			return mockedResolver
+		}, newUnsupportedMaterializationStore())
+		provider := NewLocalResolverProvider(resolverSupplier, stateProvider, &tu.MockFlagLogger{}, tu.TestClientSecret, slog.New(slog.NewTextHandler(os.Stderr, nil)), opts...)
+		if err := openfeature.SetProviderAndWait(provider); err != nil {
+			t.Fatalf("SetProviderAndWait: %v", err)
+		}
+		return mockedResolver, openfeature.NewClient("apply-time-test")
+	}
+
+	resolveRequest := func(t *testing.T, m *tu.MockedLocalResolver) *resolver.ResolveFlagsRequest {
+		t.Helper()
+		if m.LastRequest == nil {
+			t.Fatal("expected ResolveProcess to be called")
+		}
+		req := m.LastRequest.GetWithoutMaterializations()
+		if req == nil {
+			req = m.LastRequest.GetDeferredMaterializations()
+		}
+		if req == nil {
+			t.Fatalf("unexpected resolve request: %#v", m.LastRequest)
+		}
+		return req
+	}
+
+	evalCtx := openfeature.NewTargetlessEvaluationContext(map[string]interface{}{
+		"visitor_id": "tutorial_visitor",
+	})
+
+	t.Run("backdates the exposure to the provided apply time", func(t *testing.T) {
+		m, client := setup(t, response(true))
+		result, err := client.BooleanValueDetails(ctx, "tutorial-feature.enabled", false, evalCtx)
+		if err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if !result.Value {
+			t.Error("expected flag value true")
+		}
+		if resolveRequest(t, m).Apply {
+			t.Error("expected apply=false on the resolve when an apply time is set")
+		}
+		if m.LastApplyRequest == nil {
+			t.Fatal("expected ApplyFlags to be called")
+		}
+		if got := string(m.LastApplyRequest.ResolveToken); got != "test-resolve-token" {
+			t.Errorf("expected the resolve token from the resolve response, got %q", got)
+		}
+		if len(m.LastApplyRequest.Flags) != 1 {
+			t.Fatalf("expected 1 applied flag, got %d", len(m.LastApplyRequest.Flags))
+		}
+		applied := m.LastApplyRequest.Flags[0]
+		if applied.Flag != "flags/tutorial-feature" {
+			t.Errorf("expected applied flag 'flags/tutorial-feature', got %q", applied.Flag)
+		}
+		if !applied.ApplyTime.AsTime().Equal(applyTime) {
+			t.Errorf("expected apply_time %v, got %v", applyTime, applied.ApplyTime.AsTime())
+		}
+		if m.LastApplyRequest.SendTime.AsTime().Equal(applyTime) {
+			t.Error("expected send_time to be the current time, not the backdated apply time")
+		}
+	})
+
+	t.Run("_confidence_skip_apply wins", func(t *testing.T) {
+		m, client := setup(t, response(true))
+		skipCtx := openfeature.NewTargetlessEvaluationContext(map[string]interface{}{
+			"visitor_id":             "tutorial_visitor",
+			"_confidence_skip_apply": true,
+		})
+		if _, err := client.BooleanValueDetails(ctx, "tutorial-feature.enabled", false, skipCtx); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if resolveRequest(t, m).Apply {
+			t.Error("expected apply=false when _confidence_skip_apply is set")
+		}
+		if m.LastApplyRequest != nil {
+			t.Error("expected no ApplyFlags call when _confidence_skip_apply is set")
+		}
+	})
+
+	t.Run("DisableExposureCollection wins", func(t *testing.T) {
+		m, client := setup(t, response(true), WithDisableExposureCollection())
+		if _, err := client.BooleanValueDetails(ctx, "tutorial-feature.enabled", false, evalCtx); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if resolveRequest(t, m).Apply {
+			t.Error("expected apply=false when DisableExposureCollection is configured")
+		}
+		if m.LastApplyRequest != nil {
+			t.Error("expected no ApplyFlags call when DisableExposureCollection is configured")
+		}
+	})
+
+	t.Run("no apply when the resolver sets should_apply=false", func(t *testing.T) {
+		m, client := setup(t, response(false))
+		if _, err := client.BooleanValueDetails(ctx, "tutorial-feature.enabled", false, evalCtx); err != nil {
+			t.Fatalf("resolve: %v", err)
+		}
+		if m.LastApplyRequest != nil {
+			t.Error("expected no ApplyFlags call when should_apply=false")
 		}
 	})
 }


### PR DESCRIPTION
Server-side integrations often resolve a flag while handling a message whose facts are timestamped at arrival, a few seconds before the resolve. The exposure is stamped at resolve time, so the first treated message ends up on the pre-exposure side of `first_exposure`. That biases exposure-windowed metrics and contaminates the CUPED covariate; in one of our experiments it produced a +44% arm gap on a pre-randomization quantity and flipped a cost metric.

The protocol already supports this: `AppliedFlag.apply_time` is caller-supplied and `apply_flags` skew-adjusts it. The Go provider just can't set it, since `evaluate` applies inside the resolve and drops the token.

This adds `WithApplyTime(ctx, t)`. Evaluations made with that context resolve with `apply=false` and record the exposure via `ApplyFlags` with `t` as the apply time and the token from that resolve. `_confidence_skip_apply` and `DisableExposureCollection` still win. I went with a context value rather than an evaluation-context key like `_confidence_skip_apply` since the apply time is request-scoped rather than a targeting attribute, and it keeps the value typed; happy to switch if you prefer consistency with the existing key.

Go only for now. Also happy to move this into the core instead if you'd rather every provider get it in one place.