### PR TITLE
fix(ruby): build a Net::HTTP per request instead of sharing one

### DIFF
--- a/openfeature-provider/ruby/lib/confidence/openfeature/api_client.rb
+++ b/openfeature-provider/ruby/lib/confidence/openfeature/api_client.rb
@@ -22,10 +22,8 @@ module Confidence
 
     class APIClient
       def initialize(client_secret:, region: Region::EU)
-        uri = URI.parse(region.uri)
         @client_secret = client_secret
-        @agent = Net::HTTP.new(uri.host, uri.port)
-        @agent.use_ssl = uri.scheme == "https"
+        @uri = URI.parse(region.uri)
       end
 
       def resolve_one(flag:, context: {}, apply: true)
@@ -61,11 +59,33 @@ module Confidence
 
       private
 
+      # A fresh Net::HTTP per request, because one instance cannot be shared
+      # across threads. Net::HTTP#request auto-starts the connection when the
+      # receiver is not already started, mutating its @started and @socket:
+      #
+      #   unless started?
+      #     start { req['connection'] ||= 'close'; return request(req, ...) }
+      #   end
+      #
+      # Two threads entering that on the same object both open a connection and
+      # both assign @socket, so one clobbers the other and the loser reads or
+      # writes a socket the winner may already have closed.
+      #
+      # Per-request instantiation costs nothing here: the instance was never
+      # explicitly started, so every request already opened a connection, sent
+      # "Connection: close" and closed it again. There was no reuse to lose.
+      # Takes a URI so an additional endpoint can share it.
+      def build_agent(uri)
+        agent = Net::HTTP.new(uri.host, uri.port)
+        agent.use_ssl = uri.scheme == "https"
+        agent
+      end
+
       def post_json(path, body)
         headers = {"Content-Type" => "application/json"}
         request = Net::HTTP::Post.new(path, headers)
         request.body = JSON.dump(body)
-        response = @agent.request(request)
+        response = build_agent(@uri).request(request)
 
         code = response.code.to_i
         if code != 200

--- a/openfeature-provider/ruby/spec/api_client_spec.rb
+++ b/openfeature-provider/ruby/spec/api_client_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require "confidence/openfeature"
+require "rspec"
+require "json"
+require "net/http"
+
+RSpec.describe Confidence::OpenFeature::APIClient do
+  subject(:client) { described_class.new(client_secret: "secret") }
+
+  def resolved_body(flag)
+    {"resolvedFlags" => [{"flag" => flag, "variant" => "flags/#{flag}/variants/v", "value" => {"a" => 1}}]}
+  end
+
+  def ok_response(flag)
+    double("Net::HTTPOK", code: "200", message: "OK", body: JSON.dump(resolved_body(flag)))
+  end
+
+  # Records every Net::HTTP instance the client builds, and stubs #request on
+  # each so nothing touches the network. `before` blocks are not used because
+  # each example needs a different #request behaviour.
+  def capture_agents(&request_impl)
+    agents = []
+    allow(Net::HTTP).to receive(:new).and_wrap_original do |original, *args|
+      agent = original.call(*args)
+      agents << agent
+      allow(agent).to receive(:request) { |req| request_impl.call(req) }
+      agent
+    end
+    agents
+  end
+
+  # This is the deterministic guard for the thread-safety fix. A memoised,
+  # shared Net::HTTP is unsafe because #request mutates @started/@socket on the
+  # receiver, so the fix is "never share the instance". That structural
+  # property is assertable without racing anything.
+  it "builds a separate Net::HTTP for each request" do
+    agents = capture_agents { |req| ok_response(JSON.parse(req.body)["flags"].first) }
+
+    client.resolve(flags: ["flags/one"])
+    client.resolve(flags: ["flags/two"])
+
+    expect(agents.length).to eq(2)
+    expect(agents.map(&:object_id).uniq.length).to eq(2)
+  end
+
+  it "configures TLS on every agent it builds" do
+    agents = capture_agents { |req| ok_response(JSON.parse(req.body)["flags"].first) }
+
+    client.resolve(flags: ["flags/one"])
+
+    expect(agents.length).to eq(1)
+    expect(agents.first.use_ssl?).to be(true)
+    expect(agents.first.address).to eq("resolver.eu.confidence.dev")
+  end
+
+  # Concurrency smoke test. NOTE: this is deliberately NOT claimed as a
+  # red-side guard. Stubbing #request removes the socket that the real race
+  # corrupts, so this example also passes against a shared memoised agent.
+  # It exists to prove the fix introduces no cross-thread bleed of its own
+  # (each thread must see the response for the flag it asked for) and that no
+  # exception escapes. The example above is what actually fails without the fix.
+  it "gives each thread its own response under concurrency" do
+    capture_agents do |req|
+      flag = JSON.parse(req.body)["flags"].first
+      sleep 0.01 # widen the window between building the agent and responding
+      ok_response(flag)
+    end
+
+    results = {}
+    errors = []
+    threads = 8.times.map do |i|
+      Thread.new do
+        flag = "flags/f#{i}"
+        results[flag] = client.resolve(flags: [flag]).first.flag
+      rescue => ex
+        errors << ex
+      end
+    end
+    threads.each(&:join)
+
+    expect(errors).to be_empty
+    expect(results.length).to eq(8)
+    results.each { |requested, returned| expect(returned).to eq(requested) }
+  end
+end


### PR DESCRIPTION
## The defect

`APIClient` memoised a single `Net::HTTP` in its constructor and routed every `flags:resolve` through it. `Net::HTTP#request` auto-starts the connection when the receiver is not already started:

```ruby
unless started?
  start {
    req['connection'] ||= 'close'
    return request(req, body, &block)
  }
end
```

Two threads entering that on the same object both open a connection and both assign `@socket`, so one clobbers the other and the loser reads or writes a socket the winner may already have closed.

Concrete consequence in a threaded server (the documented deployment — Rails/Puma), where flag evaluation happens per web request:

- `IOError: closed stream`
- `Net::HTTPBadResponse`
- worst case, **a response delivered to the wrong caller** — one request receiving another request's flag resolution, i.e. a silently wrong flag value

There was no mutex or pool anywhere in the file. `post_json` was the only user of the shared agent, reached by both `resolve` and `resolve_one`.

This is **pre-existing on `main`** and independent of the event-tracking work in #581. Raised as its own PR so it can be reviewed and merged on its own.

## The fix, and why not a mutex

Build the `Net::HTTP` per request. No shared mutable state, so it is thread-safe by construction.

**Sharing the instance bought nothing to begin with.** Because it was never explicitly `start`ed, the auto-start path above wrapped every single request in `start { ... }` and set `Connection: close` — so each request already opened a connection and closed it again. There was no keep-alive to preserve, which makes per-request instantiation free rather than a trade-off. Verified against the stdlib in `ruby:3.3-alpine`, the image CI builds on.

A `Mutex` was rejected: it would preserve reuse that does not exist while serialising every flag evaluation in the process. Flag resolution sits on the hot path of each web request, so a process-wide lock would convert a concurrent app into serial resolution. A connection pool was rejected as unjustified complexity for the same reason — with no keep-alive today, there is nothing to pool.

`build_agent` takes a URI so an additional endpoint can share it.

## Tests

Two kinds, and I want to be precise about which is which:

- **`builds a separate Net::HTTP for each request` — the real guard.** The fix is structural ("never share the instance"), so it is assertable without racing anything. Verified deterministically: with the fix reverted, it fails `expected: 2, got: 1`.
- **`gives each thread its own response under concurrency` — a smoke test, explicitly *not* a red-side guard.** Stubbing `#request` removes the socket that the real race corrupts, so this example passes against the shared agent too. Confirmed empirically during the revert. It is retained to show the fix introduces no cross-thread bleed of its own, and the comment in the spec says so, so nobody mistakes it for coverage of the race.

Reproducing the socket race deterministically would need a real server and is inherently flaky, so I did not claim it.

## Verification

Through the Docker stages CI uses, all forced `--no-cache` (a cached layer emits no output and silently looks like a pass):

| Stage | Result |
|---|---|
| `openfeature-provider-ruby.test` | **12 examples, 0 failures** (was 9) |
| `openfeature-provider-ruby.lint` | `standard` clean, exit 0 |
| `openfeature-provider-ruby.build` | gem built — `confidence-openfeature-provider 0.1.4` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)