### PR TITLE
feat(go): abstract logging behind an interface

### DIFF
--- a/openfeature-provider/go/README.md
+++ b/openfeature-provider/go/README.md
@@ -184,7 +184,7 @@ The `ProviderConfig` struct contains all configuration options for the provider:
 
 #### Optional Fields
 
-- `Logger` (\*slog.Logger): Custom logger for provider operations. If not provided, a default text logger is created. See [Logging](#logging) for details.
+- `Logger` (`confidence.Logger`): Custom logger for provider operations. `*slog.Logger` satisfies this interface. If not provided, logging is disabled. See [Logging](#logging) for details.
 - `TransportHooks` (TransportHooks): Custom transport hooks for advanced use cases (e.g., custom gRPC interceptors, HTTP transport wrapping, TLS configuration). The default gRPC dial options include a retry policy for flag log writes (3 attempts with exponential backoff on `UNAVAILABLE`). Custom `TransportHooks` receive these options in `ModifyGRPCDial` and can keep, modify, or replace them. See [gRPC retry via service config](https://grpc.io/docs/guides/retry/) for details.
 - `StatePollInterval` (time.Duration): Interval for polling flag state updates (default: 10 seconds)
 - `LogPollInterval` (time.Duration): Interval for flushing evaluation logs (default: 60 seconds)
@@ -526,12 +526,15 @@ if err != nil {
 
 ## Logging
 
-The provider uses `log/slog` for structured logging. By default, logs at `Info` level and above are written to `stderr`.
+The provider accepts any logger that implements `confidence.Logger`. The interface follows the `log/slog` method signatures, so `*slog.Logger` can be passed directly. If no logger is provided, a no-op logger is used.
 
-You can provide a custom logger to control log level, format, and destination:
+For example, use `slog` to control log level, format, and destination:
 
 ```go
-import "log/slog"
+import (
+    "log/slog"
+    "os"
+)
 
 // JSON logger with debug level
 logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{

--- a/openfeature-provider/go/confidence/flag_logger_e2e_test.go
+++ b/openfeature-provider/go/confidence/flag_logger_e2e_test.go
@@ -2,10 +2,8 @@ package confidence
 
 import (
 	"context"
-	"log/slog"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -25,10 +23,8 @@ func TestFlagLogs_ShouldSuccessfullySendToRealBackend(t *testing.T) {
 	requireE2EEnvironmentVariable(t, "CONFIDENCE_CLIENT_SECRET", flagLogsClientSecret)
 	ctx := context.Background()
 
-	// Create a custom logger that captures log messages (Debug level to capture all logs)
-	var logBuffer logCaptureBuffer
-	captureHandler := slog.NewTextHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug})
-	logger := slog.New(captureHandler)
+	// Create a custom logger that captures log messages
+	logger := newRecorderLogger()
 
 	// Create a real provider with real gRPC connection
 	provider, err := NewProvider(ctx, ProviderConfig{
@@ -65,7 +61,7 @@ func TestFlagLogs_ShouldSuccessfullySendToRealBackend(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Verify the logs contain success message and no errors
-	logs := logBuffer.String()
+	logs := logger.String()
 	if strings.Contains(logs, "Failed to write flag logs") {
 		t.Errorf("Backend returned error - found 'Failed to write flag logs' in logs:\n%s", logs)
 	}
@@ -74,22 +70,4 @@ func TestFlagLogs_ShouldSuccessfullySendToRealBackend(t *testing.T) {
 	}
 
 	t.Log("Successfully sent WriteFlagLogs to real Confidence backend")
-}
-
-// logCaptureBuffer is a thread-safe buffer for capturing log output
-type logCaptureBuffer struct {
-	mu  sync.Mutex
-	buf strings.Builder
-}
-
-func (b *logCaptureBuffer) Write(p []byte) (n int, err error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buf.Write(p)
-}
-
-func (b *logCaptureBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return b.buf.String()
 }

--- a/openfeature-provider/go/confidence/flag_logs_test.go
+++ b/openfeature-provider/go/confidence/flag_logs_test.go
@@ -2,17 +2,16 @@ package confidence
 
 import (
 	"context"
-	"log/slog"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/open-feature/go-sdk/openfeature"
+
 	fl "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/flag_logger"
 	lr "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/local_resolver"
 	resolverv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolverinternal"
-
-	"github.com/open-feature/go-sdk/openfeature"
 )
 
 // Unit tests that verify WriteFlagLogs contains correct flag assignment data.
@@ -38,7 +37,7 @@ func setupFlagLogsUnitTest(t *testing.T) (*fl.CapturingFlagLogger, openfeature.I
 	capturingLogger := fl.NewCapturingFlagLogger()
 
 	// Create state provider that fetches from real Confidence service
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	logger := newLoggerForTest(t)
 	stateProvider := NewFlagsAdminStateFetcher(unitTestClientSecret, logger)
 
 	// Fetch initial state
@@ -50,7 +49,7 @@ func setupFlagLogsUnitTest(t *testing.T) (*fl.CapturingFlagLogger, openfeature.I
 	unsupportedMatStore := newUnsupportedMaterializationStore()
 
 	resolverSupplier := wrapResolverSupplierWithMaterializations(func(ctx context.Context, logSink lr.LogSink) lr.LocalResolver {
-		return lr.NewLocalResolverWithPoolSize(ctx, logSink, 2)
+		return lr.NewLocalResolverWithPoolSize(ctx, logSink, logger, 2)
 	}, unsupportedMatStore)
 	// Dedup is opt-in (experimental); these tests exercise its behavior.
 	provider := NewLocalResolverProvider(resolverSupplier, stateProvider, capturingLogger, unitTestClientSecret, logger, WithEnableApplyDedup())

--- a/openfeature-provider/go/confidence/inmemory_materialization_store.go
+++ b/openfeature-provider/go/confidence/inmemory_materialization_store.go
@@ -2,7 +2,6 @@ package confidence
 
 import (
 	"context"
-	"log/slog"
 	"sync"
 )
 
@@ -30,7 +29,7 @@ type inMemoryMaterializationStore struct {
 	// storage: unit -> materialization -> data
 	storage map[string]map[string]*materializationData
 	mu      sync.RWMutex
-	logger  *slog.Logger
+	logger  Logger
 	// call tracking for tests
 	readCalls  [][]ReadOp
 	writeCalls [][]WriteOp
@@ -42,9 +41,9 @@ type materializationData struct {
 }
 
 // newInMemoryMaterializationStore creates a new in-memory materialization store.
-func newInMemoryMaterializationStore(logger *slog.Logger) *inMemoryMaterializationStore {
+func newInMemoryMaterializationStore(logger Logger) *inMemoryMaterializationStore {
 	if logger == nil {
-		logger = slog.Default()
+		logger = &noopLogger{}
 	}
 	return &inMemoryMaterializationStore{
 		storage: make(map[string]map[string]*materializationData),
@@ -55,7 +54,7 @@ func newInMemoryMaterializationStore(logger *slog.Logger) *inMemoryMaterializati
 // newInMemoryMaterializationStoreWithInclusions creates a store pre-populated with inclusion data.
 // This is useful for testing materialized segment criterion evaluation.
 // The initialInclusions map structure is: unit -> materialization -> included
-func newInMemoryMaterializationStoreWithInclusions(logger *slog.Logger, initialInclusions map[string]map[string]bool) *inMemoryMaterializationStore {
+func newInMemoryMaterializationStoreWithInclusions(logger Logger, initialInclusions map[string]map[string]bool) *inMemoryMaterializationStore {
 	store := newInMemoryMaterializationStore(logger)
 
 	store.mu.Lock()

--- a/openfeature-provider/go/confidence/integration_test.go
+++ b/openfeature-provider/go/confidence/integration_test.go
@@ -2,8 +2,6 @@ package confidence
 
 import (
 	"context"
-	"log/slog"
-	"os"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -13,11 +11,12 @@ import (
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/prometheus/common/expfmt"
 	"github.com/prometheus/common/model"
+	"google.golang.org/grpc"
+
 	fl "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/flag_logger"
 	lr "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/local_resolver"
 	resolverv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolverinternal"
 	tu "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/testutil"
-	"google.golang.org/grpc"
 )
 
 // mockStateProvider provides test state for integration testing
@@ -103,7 +102,6 @@ func (m *mockGrpcStubForIntegration) GetCallsReceived() int32 {
 func TestIntegration_OpenFeatureShutdownFlushesLogs(t *testing.T) {
 	// Load test state
 	testState := tu.LoadTestResolverState(t)
-	accountID := tu.LoadTestAccountID(t)
 
 	ctx := context.Background()
 
@@ -116,7 +114,7 @@ func TestIntegration_OpenFeatureShutdownFlushesLogs(t *testing.T) {
 	mockStub := &mockGrpcStubForIntegration{
 		onCallReceived: make(chan struct{}, 100), // Buffer to prevent blocking
 	}
-	actualGrpcLogger := fl.NewGrpcWasmFlagLogger(mockStub, "test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	actualGrpcLogger := fl.NewGrpcWasmFlagLogger(mockStub, "test-client-secret", newLoggerForTest(t))
 
 	trackingLogger := &trackingFlagLogger{
 		actualLogger:       actualGrpcLogger,
@@ -124,7 +122,7 @@ func TestIntegration_OpenFeatureShutdownFlushesLogs(t *testing.T) {
 	}
 
 	// Create provider with test state
-	provider, err := createProviderWithTestState(ctx, stateProvider, accountID, trackingLogger, newUnsupportedMaterializationStore())
+	provider, err := createProviderWithTestState(t, stateProvider, trackingLogger, newUnsupportedMaterializationStore())
 	if err != nil {
 		t.Fatalf("Failed to create provider: %v", err)
 	}
@@ -200,7 +198,7 @@ func TestIntegration_OpenFeatureResolveStickyFlagMatStoreReadAndWrite(t *testing
 	mockStub := &mockGrpcStubForIntegration{
 		onCallReceived: make(chan struct{}, 100), // Buffer to prevent blocking
 	}
-	actualGrpcLogger := fl.NewGrpcWasmFlagLogger(mockStub, "test-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	actualGrpcLogger := fl.NewGrpcWasmFlagLogger(mockStub, "test-secret", newLoggerForTest(t))
 
 	trackingLogger := &trackingFlagLogger{
 		actualLogger:       actualGrpcLogger,
@@ -208,11 +206,11 @@ func TestIntegration_OpenFeatureResolveStickyFlagMatStoreReadAndWrite(t *testing
 	}
 	matStore := newInMemoryMaterializationStore(nil)
 	resolverSupplier := wrapResolverSupplierWithMaterializations(func(ctx context.Context, logSink lr.LogSink) lr.LocalResolver {
-		return lr.NewLocalResolverWithPoolSize(ctx, logSink, 2)
+		return lr.NewLocalResolverWithPoolSize(ctx, logSink, newLoggerForTest(t), 2)
 	}, matStore)
 
 	// Create provider with test state
-	provider := NewLocalResolverProvider(resolverSupplier, stateProvider, trackingLogger, "test-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	provider := NewLocalResolverProvider(resolverSupplier, stateProvider, trackingLogger, "test-secret", newLoggerForTest(t))
 
 	client := openfeature.NewClient("integration-test")
 
@@ -323,7 +321,7 @@ func TestIntegration_OpenFeatureMaterializedSegmentCriterion(t *testing.T) {
 	mockStub := &mockGrpcStubForIntegration{
 		onCallReceived: make(chan struct{}, 100),
 	}
-	actualGrpcLogger := fl.NewGrpcWasmFlagLogger(mockStub, SECRET, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	actualGrpcLogger := fl.NewGrpcWasmFlagLogger(mockStub, SECRET, newLoggerForTest(t))
 
 	trackingLogger := &trackingFlagLogger{
 		actualLogger:       actualGrpcLogger,
@@ -339,11 +337,11 @@ func TestIntegration_OpenFeatureMaterializedSegmentCriterion(t *testing.T) {
 		}
 		matStore := newInMemoryMaterializationStoreWithInclusions(nil, initialInclusions)
 		resolverSupplier := wrapResolverSupplierWithMaterializations(func(ctx context.Context, logSink lr.LogSink) lr.LocalResolver {
-			return lr.NewLocalResolverWithPoolSize(ctx, logSink, 2)
+			return lr.NewLocalResolverWithPoolSize(ctx, logSink, newLoggerForTest(t), 2)
 		}, matStore)
 
 		// Create provider with test state
-		provider := NewLocalResolverProvider(resolverSupplier, stateProvider, trackingLogger, SECRET, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+		provider := NewLocalResolverProvider(resolverSupplier, stateProvider, trackingLogger, SECRET, newLoggerForTest(t))
 
 		client := openfeature.NewClient("integration-test-mat-seg")
 
@@ -401,11 +399,11 @@ func TestIntegration_OpenFeatureMaterializedSegmentCriterion(t *testing.T) {
 		}
 		matStore := newInMemoryMaterializationStoreWithInclusions(nil, initialInclusions)
 		resolverSupplier := wrapResolverSupplierWithMaterializations(func(ctx context.Context, logSink lr.LogSink) lr.LocalResolver {
-			return lr.NewLocalResolverWithPoolSize(ctx, logSink, 2)
+			return lr.NewLocalResolverWithPoolSize(ctx, logSink, newLoggerForTest(t), 2)
 		}, matStore)
 
 		// Create provider with test state
-		provider := NewLocalResolverProvider(resolverSupplier, stateProvider, trackingLogger, SECRET, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+		provider := NewLocalResolverProvider(resolverSupplier, stateProvider, trackingLogger, SECRET, newLoggerForTest(t))
 
 		client := openfeature.NewClient("integration-test-mat-seg-not-in")
 
@@ -442,11 +440,11 @@ func TestIntegration_OpenFeatureMaterializedSegmentCriterion(t *testing.T) {
 		// Create empty materialization store (no context for tutorial_visitor)
 		matStore := newInMemoryMaterializationStore(nil)
 		resolverSupplier := wrapResolverSupplierWithMaterializations(func(ctx context.Context, logSink lr.LogSink) lr.LocalResolver {
-			return lr.NewLocalResolverWithPoolSize(ctx, logSink, 2)
+			return lr.NewLocalResolverWithPoolSize(ctx, logSink, newLoggerForTest(t), 2)
 		}, matStore)
 
 		// Create provider with test state
-		provider := NewLocalResolverProvider(resolverSupplier, stateProvider, trackingLogger, SECRET, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+		provider := NewLocalResolverProvider(resolverSupplier, stateProvider, trackingLogger, SECRET, newLoggerForTest(t))
 
 		client := openfeature.NewClient("integration-test-mat-seg-no-ctx")
 
@@ -486,7 +484,6 @@ func TestIntegration_OpenFeatureMaterializedSegmentCriterion(t *testing.T) {
 func TestIntegration_OpenFeatureObjectWithStructDefault(t *testing.T) {
 	// Load test state
 	testState := tu.LoadTestResolverState(t)
-	accountID := tu.LoadTestAccountID(t)
 
 	ctx := context.Background()
 
@@ -499,7 +496,7 @@ func TestIntegration_OpenFeatureObjectWithStructDefault(t *testing.T) {
 	mockStub := &mockGrpcStubForIntegration{
 		onCallReceived: make(chan struct{}, 100),
 	}
-	actualGrpcLogger := fl.NewGrpcWasmFlagLogger(mockStub, "mkjJruAATQWjeY7foFIWfVAcBWnci2YF", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	actualGrpcLogger := fl.NewGrpcWasmFlagLogger(mockStub, "mkjJruAATQWjeY7foFIWfVAcBWnci2YF", newLoggerForTest(t))
 
 	trackingLogger := &trackingFlagLogger{
 		actualLogger:       actualGrpcLogger,
@@ -507,7 +504,7 @@ func TestIntegration_OpenFeatureObjectWithStructDefault(t *testing.T) {
 	}
 
 	// Create provider with test state
-	provider, err := createProviderWithTestState(ctx, stateProvider, accountID, trackingLogger, newUnsupportedMaterializationStore())
+	provider, err := createProviderWithTestState(t, stateProvider, trackingLogger, newUnsupportedMaterializationStore())
 	if err != nil {
 		t.Fatalf("Failed to create provider: %v", err)
 	}
@@ -694,7 +691,6 @@ func TestIntegration_OpenFeatureObjectWithStructDefault(t *testing.T) {
 func TestIntegration_GetPrometheusMetrics(t *testing.T) {
 	// Load test state
 	testState := tu.LoadTestResolverState(t)
-	accountID := tu.LoadTestAccountID(t)
 
 	ctx := context.Background()
 
@@ -707,7 +703,7 @@ func TestIntegration_GetPrometheusMetrics(t *testing.T) {
 	mockStub := &mockGrpcStubForIntegration{
 		onCallReceived: make(chan struct{}, 100),
 	}
-	actualGrpcLogger := fl.NewGrpcWasmFlagLogger(mockStub, "mkjJruAATQWjeY7foFIWfVAcBWnci2YF", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	actualGrpcLogger := fl.NewGrpcWasmFlagLogger(mockStub, "mkjJruAATQWjeY7foFIWfVAcBWnci2YF", newLoggerForTest(t))
 
 	trackingLogger := &trackingFlagLogger{
 		actualLogger:       actualGrpcLogger,
@@ -715,7 +711,7 @@ func TestIntegration_GetPrometheusMetrics(t *testing.T) {
 	}
 
 	// Create provider with test state
-	provider, err := createProviderWithTestState(ctx, stateProvider, accountID, trackingLogger, newUnsupportedMaterializationStore())
+	provider, err := createProviderWithTestState(t, stateProvider, trackingLogger, newUnsupportedMaterializationStore())
 	if err != nil {
 		t.Fatalf("Failed to create provider: %v", err)
 	}
@@ -811,17 +807,20 @@ func TestIntegration_GetPrometheusMetrics(t *testing.T) {
 
 // createProviderWithTestState creates a provider with mock state provider and tracking logger
 func createProviderWithTestState(
-	ctx context.Context,
+	tb testing.TB,
 	stateProvider StateProvider,
-	accountID string,
-	logger FlagLogger,
+	fl FlagLogger,
 	matStore MaterializationStore,
 ) (*LocalResolverProvider, error) {
+	logger := newLoggerForTest(tb)
+
 	resolverSupplier := wrapResolverSupplierWithMaterializations(func(ctx context.Context, logSink lr.LogSink) lr.LocalResolver {
-		return lr.NewLocalResolverWithPoolSize(ctx, logSink, 2)
+		return lr.NewLocalResolverWithPoolSize(ctx, logSink, logger, 2)
 	}, matStore)
+
 	// Create provider with the client secret from test state
 	// The test state includes client secret: mkjJruAATQWjeY7foFIWfVAcBWnci2YF
-	provider := NewLocalResolverProvider(resolverSupplier, stateProvider, logger, "mkjJruAATQWjeY7foFIWfVAcBWnci2YF", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	provider := NewLocalResolverProvider(resolverSupplier, stateProvider, fl, "mkjJruAATQWjeY7foFIWfVAcBWnci2YF", logger)
+
 	return provider, nil
 }

--- a/openfeature-provider/go/confidence/internal/flag_logger/grpc.go
+++ b/openfeature-provider/go/confidence/internal/flag_logger/grpc.go
@@ -3,26 +3,26 @@ package flag_logger
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	resolverv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolverinternal"
 	"google.golang.org/grpc/metadata"
+
+	resolverv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolverinternal"
 )
 
 type GrpcFlagLogger struct {
 	stub         resolverv1.InternalFlagLoggerServiceClient
 	clientSecret string
-	logger       *slog.Logger
+	logger       Logger
 	wg           sync.WaitGroup
 	attempts     atomic.Int64
 	failures     atomic.Int64
 	TelemetryCounters
 }
 
-func NewGrpcWasmFlagLogger(stub resolverv1.InternalFlagLoggerServiceClient, clientSecret string, logger *slog.Logger) *GrpcFlagLogger {
+func NewGrpcWasmFlagLogger(stub resolverv1.InternalFlagLoggerServiceClient, clientSecret string, logger Logger) *GrpcFlagLogger {
 	return &GrpcFlagLogger{
 		stub:         stub,
 		clientSecret: clientSecret,

--- a/openfeature-provider/go/confidence/internal/flag_logger/grpc_test.go
+++ b/openfeature-provider/go/confidence/internal/flag_logger/grpc_test.go
@@ -1,18 +1,16 @@
 package flag_logger
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"log/slog"
-	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	resolverv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolverinternal"
 	"google.golang.org/grpc"
+
+	resolverv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolverinternal"
 )
 
 // mockInternalFlagLoggerServiceClient is a mock implementation for testing
@@ -37,7 +35,7 @@ func (m *mockInternalFlagLoggerServiceClient) ClientWriteFlagLogs(ctx context.Co
 
 func TestNewGrpcWasmFlagLogger(t *testing.T) {
 	mockStub := &mockInternalFlagLoggerServiceClient{}
-	logger := NewGrpcWasmFlagLogger(mockStub, "test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	logger := NewGrpcWasmFlagLogger(mockStub, "test-client-secret", newLoggerForTest(t))
 
 	if logger == nil {
 		t.Fatal("Expected logger to be created, got nil")
@@ -56,7 +54,7 @@ func TestGrpcWasmFlagLogger_Write_Empty(t *testing.T) {
 		},
 	}
 
-	logger := NewGrpcWasmFlagLogger(mockStub, "test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	logger := NewGrpcWasmFlagLogger(mockStub, "test-client-secret", newLoggerForTest(t))
 
 	// Empty request should be skipped
 	request := &resolverv1.WriteFlagLogsRequest{}
@@ -82,7 +80,7 @@ func TestGrpcWasmFlagLogger_Write_SmallRequest(t *testing.T) {
 		},
 	}
 
-	logger := NewGrpcWasmFlagLogger(mockStub, "test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	logger := NewGrpcWasmFlagLogger(mockStub, "test-client-secret", newLoggerForTest(t))
 
 	// Create a small request (below chunk threshold)
 	request := &resolverv1.WriteFlagLogsRequest{
@@ -116,7 +114,7 @@ func TestGrpcWasmFlagLogger_ErrorHandling(t *testing.T) {
 		},
 	}
 
-	logger := NewGrpcWasmFlagLogger(mockStub, "test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	logger := NewGrpcWasmFlagLogger(mockStub, "test-client-secret", newLoggerForTest(t))
 
 	request := &resolverv1.WriteFlagLogsRequest{
 		FlagAssigned: make([]*resolverv1.FlagAssigned, 10),
@@ -144,7 +142,7 @@ func TestGrpcWasmFlagLogger_Shutdown(t *testing.T) {
 		},
 	}
 
-	logger := NewGrpcWasmFlagLogger(mockStub, "test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	logger := NewGrpcWasmFlagLogger(mockStub, "test-client-secret", newLoggerForTest(t))
 
 	// Send multiple requests
 	for i := 0; i < 5; i++ {
@@ -163,8 +161,7 @@ func TestGrpcWasmFlagLogger_Shutdown(t *testing.T) {
 }
 
 func TestGrpcWasmFlagLogger_FailureStats_NoLogOnSuccess(t *testing.T) {
-	var buf bytes.Buffer
-	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	testLogger := newWarningRecorderLogger()
 
 	mockStub := &mockInternalFlagLoggerServiceClient{
 		writeFlagLogsFunc: func(ctx context.Context, req *resolverv1.WriteFlagLogsRequest) (*resolverv1.WriteFlagLogsResponse, error) {
@@ -181,14 +178,13 @@ func TestGrpcWasmFlagLogger_FailureStats_NoLogOnSuccess(t *testing.T) {
 	}
 	logger.Shutdown()
 
-	if strings.Contains(buf.String(), "Flag log write failures") {
+	if strings.Contains(testLogger.String(), "Flag log write failures") {
 		t.Error("Expected no failure log when all writes succeed")
 	}
 }
 
 func TestGrpcWasmFlagLogger_FailureStats_LogOnFailures(t *testing.T) {
-	var buf bytes.Buffer
-	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	testLogger := newWarningRecorderLogger()
 
 	var callCount atomic.Int32
 	mockStub := &mockInternalFlagLoggerServiceClient{
@@ -210,15 +206,14 @@ func TestGrpcWasmFlagLogger_FailureStats_LogOnFailures(t *testing.T) {
 	}
 	logger.Shutdown()
 
-	output := buf.String()
+	output := testLogger.String()
 	if !strings.Contains(output, "Flag log write failures") {
 		t.Error("Expected failure log after window with errors")
 	}
 }
 
 func TestGrpcWasmFlagLogger_FailureStats_NoLogBeforeWindow(t *testing.T) {
-	var buf bytes.Buffer
-	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	testLogger := newWarningRecorderLogger()
 
 	mockStub := &mockInternalFlagLoggerServiceClient{
 		writeFlagLogsFunc: func(ctx context.Context, req *resolverv1.WriteFlagLogsRequest) (*resolverv1.WriteFlagLogsResponse, error) {
@@ -236,14 +231,13 @@ func TestGrpcWasmFlagLogger_FailureStats_NoLogBeforeWindow(t *testing.T) {
 	}
 	logger.Shutdown()
 
-	if strings.Contains(buf.String(), "Flag log write failures") {
+	if strings.Contains(testLogger.String(), "Flag log write failures") {
 		t.Error("Expected no failure log before window boundary")
 	}
 }
 
 func TestGrpcWasmFlagLogger_FailureStats_AllFail(t *testing.T) {
-	var buf bytes.Buffer
-	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	testLogger := newWarningRecorderLogger()
 
 	mockStub := &mockInternalFlagLoggerServiceClient{
 		writeFlagLogsFunc: func(ctx context.Context, req *resolverv1.WriteFlagLogsRequest) (*resolverv1.WriteFlagLogsResponse, error) {
@@ -260,7 +254,7 @@ func TestGrpcWasmFlagLogger_FailureStats_AllFail(t *testing.T) {
 	}
 	logger.Shutdown()
 
-	output := buf.String()
+	output := testLogger.String()
 	if !strings.Contains(output, "Flag log write failures") {
 		t.Error("Expected failure log after window with all failures")
 	}

--- a/openfeature-provider/go/confidence/internal/flag_logger/logger.go
+++ b/openfeature-provider/go/confidence/internal/flag_logger/logger.go
@@ -1,0 +1,14 @@
+package flag_logger
+
+// Logger is the subset of the top-level confidence.Logger interface required by
+// this package.
+//
+// Only Debug and Warn are used: Debug for successful send traces and Warn for
+// periodic failure summaries reported every 10 write attempts.
+//
+// The variadic args follow the slog convention: alternating string key / arbitrary
+// value pairs.
+type Logger interface {
+	Debug(msg string, args ...any)
+	Warn(msg string, args ...any)
+}

--- a/openfeature-provider/go/confidence/internal/flag_logger/logger_test.go
+++ b/openfeature-provider/go/confidence/internal/flag_logger/logger_test.go
@@ -1,0 +1,80 @@
+package flag_logger
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// testingLogger routes log messages to [testing.TB.Log] so they appear in test
+// output only on failure (or with -v).
+type testingLogger struct {
+	log func(msgs ...any)
+}
+
+// newLoggerForTest returns a [Logger] backed by tb.Log.
+func newLoggerForTest(tb testing.TB) *testingLogger {
+	return &testingLogger{
+		log: tb.Log,
+	}
+}
+
+func (l *testingLogger) Debug(msg string, args ...any) {
+	l.logMessage("debug", msg, args...)
+}
+
+func (l *testingLogger) Warn(msg string, args ...any) {
+	l.logMessage("warning", msg, args...)
+}
+
+func (l *testingLogger) logMessage(lvl string, msg string, args ...any) {
+	var fields string
+
+	if len(args) > 0 {
+		var sb strings.Builder
+
+		sb.WriteRune('{')
+		for len(args) > 0 {
+			k, v := args[0].(string), args[1]
+			if sb.Len() > 1 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(fmt.Sprintf("%s: %v", k, v))
+			args = args[2:]
+		}
+		sb.WriteRune('}')
+
+		fields = sb.String()
+	}
+
+	l.log(fmt.Sprintf("[%s] %s", lvl, msg), fields)
+}
+
+// warningRecorderLogger captures only Warn calls so tests can assert on warning
+// output without noise from Debug messages.
+type warningRecorderLogger struct {
+	buf bytes.Buffer
+}
+
+// newWarningRecorderLogger returns an empty [warningRecorderLogger].
+func newWarningRecorderLogger() *warningRecorderLogger {
+	return &warningRecorderLogger{}
+}
+
+func (l *warningRecorderLogger) Debug(msg string, args ...any) {}
+
+func (l *warningRecorderLogger) Warn(msg string, args ...any) {
+	l.buf.WriteString(msg)
+	defer l.buf.WriteRune('\n')
+
+	for len(args) > 0 {
+		k, v := args[0].(string), args[1]
+		l.buf.WriteString(fmt.Sprintf(" %s=%v", k, v))
+		args = args[2:]
+	}
+}
+
+func (l *warningRecorderLogger) String() string {
+	return l.buf.String()
+}

--- a/openfeature-provider/go/confidence/internal/flag_logger/logger_test.go
+++ b/openfeature-provider/go/confidence/internal/flag_logger/logger_test.go
@@ -7,16 +7,15 @@ import (
 	"testing"
 )
 
-// testingLogger routes log messages to [testing.TB.Log] so they appear in test
-// output only on failure (or with -v).
+// testingLogger accepts log messages without retaining test state.
 type testingLogger struct {
 	log func(msgs ...any)
 }
 
-// newLoggerForTest returns a [Logger] backed by tb.Log.
-func newLoggerForTest(tb testing.TB) *testingLogger {
+// newLoggerForTest returns a no-op [Logger] safe for background goroutines.
+func newLoggerForTest(_ testing.TB) *testingLogger {
 	return &testingLogger{
-		log: tb.Log,
+		log: func(...any) {},
 	}
 }
 

--- a/openfeature-provider/go/confidence/internal/flag_logger/multi.go
+++ b/openfeature-provider/go/confidence/internal/flag_logger/multi.go
@@ -3,7 +3,6 @@ package flag_logger
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -22,7 +21,7 @@ type logSender func(ctx context.Context, request *resolverv1.WriteFlagLogsReques
 type MultiDestinationFlagLogger struct {
 	senders      map[admin.LogDestination]logSender
 	destinations func() []admin.LogDestination
-	logger       *slog.Logger
+	logger       Logger
 	wg           sync.WaitGroup
 	attempts     atomic.Int64
 	failures     atomic.Int64
@@ -42,7 +41,7 @@ func NewMultiDestinationFlagLogger(
 	clientSecret string,
 	destinations func() []admin.LogDestination,
 	accountID func() string,
-	logger *slog.Logger,
+	logger Logger,
 ) *MultiDestinationFlagLogger {
 	httpS := newHttpSender(clientSecret, accountID, nil)
 

--- a/openfeature-provider/go/confidence/internal/local_resolver/default_resolver_test.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/default_resolver_test.go
@@ -5,18 +5,18 @@ import (
 	"os"
 	"testing"
 
+	"google.golang.org/protobuf/types/known/structpb"
+
 	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolver"
 	resolverv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolverinternal"
 	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/wasm"
 	tu "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/testutil"
-
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 var resolverFactory LocalResolverFactory
 
 func TestMain(m *testing.M) {
-	resolverFactory = DefaultResolverFactory(NoOpLogSink, LocalResolverConfig{})
+	resolverFactory = DefaultResolverFactory(NoOpLogSink, LocalResolverConfig{Logger: &noopLogger{}})
 	defer resolverFactory.Close(context.Background())
 	os.Exit(m.Run())
 }
@@ -47,7 +47,7 @@ func TestSwapWasmResolverApi_NewSwapWasmResolverApi(t *testing.T) {
 func TestSwapWasmResolverApi_WithRealState_InterpreterMode(t *testing.T) {
 	ctx := context.Background()
 
-	factory := NewWasmResolverFactory(NoOpLogSink, true)
+	factory := NewWasmResolverFactory(NoOpLogSink, newLoggerForTest(t), true)
 	defer factory.Close(ctx)
 
 	testState := tu.LoadTestResolverState(t)
@@ -442,7 +442,7 @@ func TestDisableExposureCollection_FlushAllLogsSendsResolvesNotAssigns(t *testin
 	var captured []*resolverv1.WriteFlagLogsRequest
 	factory := NewWasmResolverFactory(func(logs *resolverv1.WriteFlagLogsRequest) {
 		captured = append(captured, logs)
-	}, false)
+	}, newLoggerForTest(t), false)
 	defer factory.Close(ctx)
 
 	resolver := factory.New()

--- a/openfeature-provider/go/confidence/internal/local_resolver/local_resolver.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/local_resolver.go
@@ -14,6 +14,7 @@ const DefaultPoolSize = 2
 type LocalResolverConfig struct {
 	PoolSize           int
 	UseWasmInterpreter bool
+	Logger             Logger
 }
 
 type LocalResolverSupplier func() LocalResolver
@@ -39,8 +40,9 @@ type LocalResolver interface {
 
 // DefaultResolverFactory composes the default stack: Wasm -> Recovering -> Pooled(DefaultPoolSize)
 func DefaultResolverFactory(logSink LogSink, cfg LocalResolverConfig) LocalResolverFactory {
-	base := NewWasmResolverFactory(logSink, cfg.UseWasmInterpreter)
-	rcv := NewRecoveringResolverFactory(base)
+	logger := defaultLogger(cfg.Logger)
+	base := NewWasmResolverFactory(logSink, logger, cfg.UseWasmInterpreter)
+	rcv := NewRecoveringResolverFactory(base, logger)
 	poolSize := cfg.PoolSize
 	if poolSize <= 0 {
 		poolSize = DefaultPoolSize
@@ -53,17 +55,18 @@ type localResolverImpl struct {
 	factory LocalResolverFactory
 }
 
-func NewLocalResolverWithPoolSize(ctx context.Context, logSink LogSink, poolSize int) LocalResolver {
-	return NewLocalResolver(ctx, logSink, LocalResolverConfig{PoolSize: poolSize})
+func NewLocalResolverWithPoolSize(ctx context.Context, logSink LogSink, logger Logger, poolSize int) LocalResolver {
+	return NewLocalResolver(ctx, logSink, LocalResolverConfig{PoolSize: poolSize, Logger: logger})
 }
 
 func NewLocalResolver(ctx context.Context, logSink LogSink, cfg LocalResolverConfig) LocalResolver {
+	logger := defaultLogger(cfg.Logger)
 	poolSize := cfg.PoolSize
 	if poolSize <= 0 {
 		poolSize = DefaultPoolSize
 	}
-	factory := NewWasmResolverFactory(logSink, cfg.UseWasmInterpreter)
-	factory = NewRecoveringResolverFactory(factory)
+	factory := NewWasmResolverFactory(logSink, logger, cfg.UseWasmInterpreter)
+	factory = NewRecoveringResolverFactory(factory, logger)
 	return &localResolverImpl{
 		PooledResolver: *NewPooledResolver(poolSize, factory.New),
 		factory:        factory,

--- a/openfeature-provider/go/confidence/internal/local_resolver/logger.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/logger.go
@@ -1,0 +1,25 @@
+package local_resolver
+
+// Logger is the subset of the top-level confidence.Logger interface required by
+// this package.
+//
+// Only Warn is used: to report WASM instance crashes caught by [RecoveringResolver]
+// and to surface pool saturation events.
+//
+// The variadic args follow the slog convention: alternating string key / arbitrary
+// value pairs.
+type Logger interface {
+	Warn(msg string, args ...any)
+}
+
+// noopLogger is the default Logger used when none is provided by the caller.
+type noopLogger struct{}
+
+func (l *noopLogger) Warn(_ string, _ ...any) {}
+
+func defaultLogger(logger Logger) Logger {
+	if logger == nil {
+		return &noopLogger{}
+	}
+	return logger
+}

--- a/openfeature-provider/go/confidence/internal/local_resolver/logger_test.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/logger_test.go
@@ -1,0 +1,47 @@
+package local_resolver
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// testingLogger routes log messages to [testing.TB.Log] so they appear in test
+// output only on failure (or with -v).
+type testingLogger struct {
+	log func(msgs ...any)
+}
+
+// newLoggerForTest returns a [Logger] backed by tb.Log.
+func newLoggerForTest(tb testing.TB) *testingLogger {
+	return &testingLogger{
+		log: tb.Log,
+	}
+}
+
+func (l *testingLogger) Warn(msg string, args ...any) {
+	l.logMessage("warning", msg, args...)
+}
+
+func (l *testingLogger) logMessage(lvl string, msg string, args ...any) {
+	var fields string
+
+	if len(args) > 0 {
+		var sb strings.Builder
+
+		sb.WriteRune('{')
+		for len(args) > 0 {
+			k, v := args[0].(string), args[1]
+			if sb.Len() > 1 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(fmt.Sprintf("%s: %v", k, v))
+			args = args[2:]
+		}
+		sb.WriteRune('}')
+
+		fields = sb.String()
+	}
+
+	l.log(fmt.Sprintf("[%s] %s", lvl, msg), fields)
+}

--- a/openfeature-provider/go/confidence/internal/local_resolver/logger_test.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/logger_test.go
@@ -6,16 +6,15 @@ import (
 	"testing"
 )
 
-// testingLogger routes log messages to [testing.TB.Log] so they appear in test
-// output only on failure (or with -v).
+// testingLogger accepts log messages without retaining test state.
 type testingLogger struct {
 	log func(msgs ...any)
 }
 
-// newLoggerForTest returns a [Logger] backed by tb.Log.
-func newLoggerForTest(tb testing.TB) *testingLogger {
+// newLoggerForTest returns a no-op [Logger] safe for background goroutines.
+func newLoggerForTest(_ testing.TB) *testingLogger {
 	return &testingLogger{
-		log: tb.Log,
+		log: func(...any) {},
 	}
 }
 

--- a/openfeature-provider/go/confidence/internal/local_resolver/recover.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/recover.go
@@ -3,7 +3,6 @@ package local_resolver
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"sync/atomic"
 	"time"
 
@@ -15,15 +14,20 @@ import (
 // LocalResolver instances that auto-recover (recreate) on low-level panics.
 type RecoveringResolverFactory struct {
 	LocalResolverFactory
+	logger Logger
 }
 
-func NewRecoveringResolverFactory(inner LocalResolverFactory) *RecoveringResolverFactory {
-	return &RecoveringResolverFactory{inner}
+func NewRecoveringResolverFactory(inner LocalResolverFactory, logger Logger) *RecoveringResolverFactory {
+	return &RecoveringResolverFactory{
+		LocalResolverFactory: inner,
+		logger:               logger,
+	}
 }
 
 func (f *RecoveringResolverFactory) New() LocalResolver {
 	rr := &RecoveringResolver{
 		factory: f.LocalResolverFactory,
+		logger:  f.logger,
 	}
 	lr := f.LocalResolverFactory.New()
 	rr.current.Store(lr)
@@ -35,6 +39,7 @@ func (f *RecoveringResolverFactory) New() LocalResolver {
 // resolver can be reinitialized before use.
 type RecoveringResolver struct {
 	factory LocalResolverFactory
+	logger  Logger
 
 	current atomic.Value // holds LocalResolver
 	broken  atomic.Bool  // indicates an instance has panicked
@@ -103,7 +108,7 @@ func (r *RecoveringResolver) SetResolverState(request *wasm.SetResolverStateRequ
 func (r *RecoveringResolver) RegisterResolve(request *wasm.RegisterResolveRequest) {
 	defer func() {
 		if rec := recover(); rec != nil {
-			slog.Warn("RegisterResolve panicked, ignoring", "error", rec)
+			r.logger.Warn("RegisterResolve panicked, ignoring", "error", rec)
 		}
 	}()
 	if r.broken.Load() {
@@ -144,7 +149,7 @@ func (r *RecoveringResolver) FlushAssignLogs() (err error) {
 func (r *RecoveringResolver) PrometheusSnapshot(bucketsPerDecade uint32, openmetrics bool) string {
 	defer func() {
 		if rec := recover(); rec != nil {
-			slog.Warn("PrometheusSnapshot panicked, ignoring", "error", rec)
+			r.logger.Warn("PrometheusSnapshot panicked, ignoring", "error", rec)
 		}
 	}()
 	if r.broken.Load() {

--- a/openfeature-provider/go/confidence/internal/local_resolver/recover_test.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/recover_test.go
@@ -50,7 +50,7 @@ func (f *mockFactory) Close(context.Context) error { return nil }
 // subsequent calls succeed.
 func TestRecoveringResolver_RecreatesAfterPanic(t *testing.T) {
 	inner := &mockFactory{}
-	factory := NewRecoveringResolverFactory(inner)
+	factory := NewRecoveringResolverFactory(inner, newLoggerForTest(t))
 	rr := factory.New()
 
 	// First call: the mockResolver (shouldPanic=true) panics, withRecover

--- a/openfeature-provider/go/confidence/internal/local_resolver/wasm.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/wasm.go
@@ -6,18 +6,17 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"log/slog"
 	"sync"
 	"sync/atomic"
 
-	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/wasm"
-
-	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolver"
-	resolverv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolverinternal"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolver"
+	resolverv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolverinternal"
+	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/wasm"
 )
 
 // instanceCounter is a package-level counter for auto-assigning unique instance IDs.
@@ -39,6 +38,7 @@ func NoOpLogSink(logs *resolverv1.WriteFlagLogsRequest) {}
 type WasmResolver struct {
 	instance   api.Module
 	logSink    LogSink
+	logger     Logger
 	mu         *sync.Mutex
 	instanceID string
 	fnCache    sync.Map
@@ -74,14 +74,14 @@ func (r *WasmResolver) ResolveProcess(request *wasm.ResolveProcessRequest) (*was
 
 func (r *WasmResolver) RegisterResolve(request *wasm.RegisterResolveRequest) {
 	if err := r.call("wasm_msg_guest_register_resolve", request, nil); err != nil {
-		slog.Warn("Failed to register resolve telemetry", "error", err)
+		r.logger.Warn("Failed to register resolve telemetry", "error", err)
 	}
 }
 
 func (r *WasmResolver) ApplyFlags(request *resolver.ApplyFlagsRequest) error {
 	if err := r.call("wasm_msg_guest_apply_flags", request, nil); err != nil {
 		// Apply is best-effort logging — surface the failure but don't propagate.
-		slog.Warn("Failed to apply flags", "error", err)
+		r.logger.Warn("Failed to apply flags", "error", err)
 	}
 	return nil
 }
@@ -112,7 +112,7 @@ func (r *WasmResolver) PrometheusSnapshot(bucketsPerDecade uint32, openmetrics b
 	}
 	resp := &wasm.PrometheusSnapshotResponse{}
 	if err := r.call("wasm_msg_guest_prometheus_snapshot", req, resp); err != nil {
-		slog.Warn("prometheus snapshot failed", "error", err)
+		r.logger.Warn("prometheus snapshot failed", "error", err)
 		return ""
 	}
 	return resp.GetText()
@@ -164,6 +164,7 @@ type WasmResolverFactory struct {
 	runtime wazero.Runtime
 	module  wazero.CompiledModule
 	logSink LogSink
+	logger  Logger
 }
 
 var _ LocalResolverFactory = (*WasmResolverFactory)(nil)
@@ -188,7 +189,8 @@ func transferResponseError(inst api.Module, errMsg string) uint32 {
 	return transfer(inst, mustMarshal(resp))
 }
 
-func NewWasmResolverFactory(logSink LogSink, useInterpreter bool) LocalResolverFactory {
+func NewWasmResolverFactory(logSink LogSink, logger Logger, useInterpreter bool) LocalResolverFactory {
+	logger = defaultLogger(logger)
 	ctx := context.Background()
 	var runtime wazero.Runtime
 	if useInterpreter {
@@ -217,6 +219,7 @@ func NewWasmResolverFactory(logSink LogSink, useInterpreter bool) LocalResolverF
 		runtime: runtime,
 		module:  module,
 		logSink: logSink,
+		logger:  logger,
 	}
 }
 
@@ -231,6 +234,7 @@ func (wrf *WasmResolverFactory) New() LocalResolver {
 	return &WasmResolver{
 		instance:   instance,
 		logSink:    wrf.logSink,
+		logger:     wrf.logger,
 		mu:         &sync.Mutex{},
 		instanceID: fmt.Sprintf("%d", id),
 	}

--- a/openfeature-provider/go/confidence/internal/local_resolver/wasm_bench_test.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/wasm_bench_test.go
@@ -11,7 +11,7 @@ import (
 
 func setupBenchResolver(b *testing.B, useInterpreter bool) (LocalResolver, *wasm.ResolveProcessRequest) {
 	b.Helper()
-	factory := NewWasmResolverFactory(NoOpLogSink, useInterpreter)
+	factory := NewWasmResolverFactory(NoOpLogSink, &noopLogger{}, useInterpreter)
 	b.Cleanup(func() { _ = factory.Close(context.Background()) })
 
 	resolver := factory.New()

--- a/openfeature-provider/go/confidence/internal/local_resolver/wasm_close_test.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/wasm_close_test.go
@@ -12,7 +12,7 @@ import (
 // A resolve on a closed instance must end in a recoverable panic, never in a
 // nil fn.Call (in production that dies as a silent SIGSEGV, exit 139).
 func TestResolveOnClosedInstancePanics(t *testing.T) {
-	factory := NewWasmResolverFactory(NoOpLogSink, false)
+	factory := NewWasmResolverFactory(NoOpLogSink, newLoggerForTest(t), false)
 	defer factory.Close(context.Background())
 
 	resolver := factory.New()

--- a/openfeature-provider/go/confidence/internal/local_resolver/wasm_memory_test.go
+++ b/openfeature-provider/go/confidence/internal/local_resolver/wasm_memory_test.go
@@ -14,7 +14,7 @@ import (
 // does not free the guest's request allocation, memory leaks accumulate and
 // eventually force WASM memory.grow.
 func TestWasmMemoryStableOnRepeatedResolveCalls(t *testing.T) {
-	factory := NewWasmResolverFactory(NoOpLogSink, false)
+	factory := NewWasmResolverFactory(NoOpLogSink, newLoggerForTest(t), false)
 	defer factory.Close(context.Background())
 
 	resolver := factory.New()

--- a/openfeature-provider/go/confidence/logger.go
+++ b/openfeature-provider/go/confidence/logger.go
@@ -1,0 +1,28 @@
+package confidence
+
+// Logger is the logging interface accepted by [ProviderConfig] and [ProviderTestConfig].
+//
+// Implementations must be safe for concurrent use, as the provider calls Logger
+// from multiple goroutines (state polling, log flushing, WASM crash recovery).
+//
+// The variadic args follow the slog convention: alternating string key / arbitrary
+// value pairs, e.g.:
+//
+//	logger.Warn("retry limit reached", "attempt", 3, "flag", "my-flag")
+//
+// A nil Logger is accepted by [NewProvider] and [NewProviderForTest]; it is
+// silently replaced with a no-op implementation.
+type Logger interface {
+	Debug(msg string, args ...any)
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+	Error(msg string, args ...any)
+}
+
+// noopLogger is the default Logger used when none is provided by the caller.
+type noopLogger struct{}
+
+func (l *noopLogger) Debug(_ string, _ ...any) {}
+func (l *noopLogger) Info(_ string, _ ...any)  {}
+func (l *noopLogger) Warn(_ string, _ ...any)  {}
+func (l *noopLogger) Error(_ string, _ ...any) {}

--- a/openfeature-provider/go/confidence/logger_compat_test.go
+++ b/openfeature-provider/go/confidence/logger_compat_test.go
@@ -1,0 +1,22 @@
+package confidence_test
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence"
+)
+
+func TestProviderConfigAcceptsSlogLogger(t *testing.T) {
+	var output bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&output, nil))
+	config := confidence.ProviderConfig{Logger: logger}
+
+	config.Logger.Info("hello from slog")
+
+	if !strings.Contains(output.String(), "hello from slog") {
+		t.Fatalf("expected slog output, got %q", output.String())
+	}
+}

--- a/openfeature-provider/go/confidence/logger_test.go
+++ b/openfeature-provider/go/confidence/logger_test.go
@@ -1,0 +1,110 @@
+package confidence
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// testingLogger routes log messages to [testing.TB.Log] so they appear in test
+// output only on failure (or with -v).
+type testingLogger struct {
+	log func(msgs ...any)
+}
+
+// newLoggerForTest returns a [Logger] backed by tb.Log.
+func newLoggerForTest(tb testing.TB) *testingLogger {
+	return &testingLogger{
+		log: tb.Log,
+	}
+}
+
+func (l *testingLogger) Debug(msg string, args ...any) {
+	l.logMessage("debug", msg, args...)
+}
+
+func (l *testingLogger) Info(msg string, args ...any) {
+	l.logMessage("info", msg, args...)
+}
+
+func (l *testingLogger) Warn(msg string, args ...any) {
+	l.logMessage("warning", msg, args...)
+}
+
+func (l *testingLogger) Error(msg string, args ...any) {
+	l.logMessage("error", msg, args...)
+}
+
+func (l *testingLogger) logMessage(lvl string, msg string, args ...any) {
+	var fields string
+
+	if len(args) > 0 {
+		var sb strings.Builder
+
+		sb.WriteRune('{')
+		for len(args) > 0 {
+			k, v := args[0].(string), args[1]
+			if sb.Len() > 1 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString(fmt.Sprintf("%s: %v", k, v))
+			args = args[2:]
+		}
+		sb.WriteRune('}')
+
+		fields = sb.String()
+	}
+
+	l.log(fmt.Sprintf("[%s] %s", lvl, msg), fields)
+}
+
+// recorderLogger accumulates all log lines in a buffer so tests can assert on
+// logged output. It is safe for concurrent use.
+type recorderLogger struct {
+	l   sync.Mutex
+	buf bytes.Buffer
+}
+
+// newRecorderLogger returns an empty [recorderLogger].
+func newRecorderLogger() *recorderLogger {
+	return &recorderLogger{}
+}
+
+func (l *recorderLogger) Debug(msg string, args ...any) {
+	l.log(msg, args...)
+}
+
+func (l *recorderLogger) Info(msg string, args ...any) {
+	l.log(msg, args...)
+}
+
+func (l *recorderLogger) Warn(msg string, args ...any) {
+	l.log(msg, args...)
+}
+
+func (l *recorderLogger) Error(msg string, args ...any) {
+	l.log(msg, args...)
+}
+
+func (l *recorderLogger) log(msg string, args ...any) {
+	l.l.Lock()
+	defer l.l.Unlock()
+
+	l.buf.WriteString(msg)
+	defer l.buf.WriteRune('\n')
+
+	for len(args) > 0 {
+		k, v := args[0].(string), args[1]
+		l.buf.WriteString(fmt.Sprintf(" %s=%v", k, v))
+		args = args[2:]
+	}
+}
+
+func (l *recorderLogger) String() string {
+	l.l.Lock()
+	defer l.l.Unlock()
+
+	return l.buf.String()
+}

--- a/openfeature-provider/go/confidence/logger_test.go
+++ b/openfeature-provider/go/confidence/logger_test.go
@@ -8,16 +8,15 @@ import (
 	"testing"
 )
 
-// testingLogger routes log messages to [testing.TB.Log] so they appear in test
-// output only on failure (or with -v).
+// testingLogger accepts log messages without retaining test state.
 type testingLogger struct {
 	log func(msgs ...any)
 }
 
-// newLoggerForTest returns a [Logger] backed by tb.Log.
-func newLoggerForTest(tb testing.TB) *testingLogger {
+// newLoggerForTest returns a no-op [Logger] safe for background goroutines.
+func newLoggerForTest(_ testing.TB) *testingLogger {
 	return &testingLogger{
-		log: tb.Log,
+		log: func(...any) {},
 	}
 }
 

--- a/openfeature-provider/go/confidence/provider.go
+++ b/openfeature-provider/go/confidence/provider.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -123,7 +122,7 @@ type LocalResolverProvider struct {
 	stateProvider     StateProvider
 	flagLogger        FlagLogger
 	clientSecret      string
-	logger            *slog.Logger
+	logger            Logger
 	cancelFunc        context.CancelFunc
 	wg                sync.WaitGroup
 	mu                sync.Mutex
@@ -158,14 +157,12 @@ func NewLocalResolverProvider(
 	stateProvider StateProvider,
 	flagLogger FlagLogger,
 	clientSecret string,
-	logger *slog.Logger,
+	logger Logger,
 	opts ...Option,
 ) *LocalResolverProvider {
 	// Create a default logger if none provided
 	if logger == nil {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-			Level: slog.LevelInfo,
-		}))
+		logger = &noopLogger{}
 	}
 
 	// Apply options
@@ -1028,7 +1025,7 @@ func (p *LocalResolverProvider) startScheduledTasks(parentCtx context.Context, a
 
 // getStatePollInterval gets the state poll interval from environment or returns default
 // Deprecated: Use ProviderConfig.StatePollInterval instead. Environment variable support will be removed in a future version.
-func getStatePollInterval(logger *slog.Logger) time.Duration {
+func getStatePollInterval(logger Logger) time.Duration {
 	if envVal := os.Getenv("CONFIDENCE_STATE_POLL_INTERVAL_SECONDS"); envVal != "" {
 		if seconds, err := strconv.ParseInt(envVal, 10, 64); err == nil {
 			if logger != nil {
@@ -1042,7 +1039,7 @@ func getStatePollInterval(logger *slog.Logger) time.Duration {
 
 // getLogPollInterval gets the log poll interval from environment or returns default
 // Deprecated: Use ProviderConfig.LogPollInterval instead. Environment variable support will be removed in a future version.
-func getLogPollInterval(logger *slog.Logger) time.Duration {
+func getLogPollInterval(logger Logger) time.Duration {
 	if envVal := os.Getenv("CONFIDENCE_LOG_POLL_INTERVAL_SECONDS"); envVal != "" {
 		if seconds, err := strconv.ParseInt(envVal, 10, 64); err == nil {
 			if logger != nil {

--- a/openfeature-provider/go/confidence/provider_builder.go
+++ b/openfeature-provider/go/confidence/provider_builder.go
@@ -3,9 +3,7 @@ package confidence
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
-	"os"
 	"strconv"
 	"time"
 
@@ -22,7 +20,7 @@ const confidenceDomain = "edge-grpc.spotify.com"
 type ProviderConfig struct {
 	ClientSecret                  string
 	EncryptionKey                 string // Optional: hex-encoded AES-256 key for decrypting CDN state
-	Logger                        *slog.Logger
+	Logger                        Logger
 	TransportHooks                TransportHooks       // Optional: defaults to DefaultTransportHooks
 	MaterializationStore          MaterializationStore // Optional
 	UseRemoteMaterializationStore bool                 // set to true to use a Remote lookup for materializations. Requires that MaterializationStore is nil.
@@ -41,7 +39,7 @@ type ProviderTestConfig struct {
 	StateProvider        StateProvider
 	FlagLogger           FlagLogger
 	ClientSecret         string
-	Logger               *slog.Logger
+	Logger               Logger
 	MaterializationStore MaterializationStore // Optional
 	StatePollInterval    time.Duration        // Optional: interval for state polling, defaults to 10 seconds
 	LogPollInterval      time.Duration        // Optional: interval for log flushing, defaults to 60 seconds
@@ -60,9 +58,7 @@ func NewProvider(ctx context.Context, config ProviderConfig) (*LocalResolverProv
 
 	logger := config.Logger
 	if logger == nil {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-			Level: slog.LevelInfo,
-		}))
+		logger = &noopLogger{}
 	}
 
 	if config.EncryptionKey == "" {
@@ -109,7 +105,7 @@ func NewProvider(ctx context.Context, config ProviderConfig) (*LocalResolverProv
 	initLabels := map[string]string{
 		"encryption": strconv.FormatBool(config.EncryptionKey != ""),
 	}
-	resolverSupplier := newLocalResolverSupplier(config.ResolverPoolSize, config.UseWasmInterpreter, initLabels)
+	resolverSupplier := newLocalResolverSupplier(config.ResolverPoolSize, config.UseWasmInterpreter, logger, initLabels)
 	resolverSupplierWithMaterialization := wrapResolverSupplierWithMaterializations(resolverSupplier, materializationStore)
 	providerOpts := buildProviderOptions(config.StatePollInterval, config.LogPollInterval, config.EnableApplyDedup, config.DisableExposureCollection)
 	providerOpts = append(providerOpts,
@@ -131,16 +127,14 @@ func NewProviderForTest(ctx context.Context, config ProviderTestConfig) (*LocalR
 
 	logger := config.Logger
 	if logger == nil {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
-			Level: slog.LevelInfo,
-		}))
+		logger = &noopLogger{}
 	}
 
 	materializationStore := config.MaterializationStore
 	if materializationStore == nil {
 		materializationStore = newUnsupportedMaterializationStore()
 	}
-	resolverSupplier := newLocalResolverSupplier(config.ResolverPoolSize, config.UseWasmInterpreter, nil)
+	resolverSupplier := newLocalResolverSupplier(config.ResolverPoolSize, config.UseWasmInterpreter, logger, nil)
 	resolverSupplierWithMaterialization := wrapResolverSupplierWithMaterializations(resolverSupplier, materializationStore)
 	providerOpts := buildProviderOptions(config.StatePollInterval, config.LogPollInterval, false, config.DisableExposureCollection)
 	provider := NewLocalResolverProvider(resolverSupplierWithMaterialization, config.StateProvider, config.FlagLogger, config.ClientSecret, logger, providerOpts...)
@@ -148,10 +142,11 @@ func NewProviderForTest(ctx context.Context, config ProviderTestConfig) (*LocalR
 	return provider, nil
 }
 
-func newLocalResolverSupplier(poolSize int, useWasmInterpreter bool, initLabels map[string]string) func(context.Context, lr.LogSink) lr.LocalResolver {
+func newLocalResolverSupplier(poolSize int, useWasmInterpreter bool, logger Logger, initLabels map[string]string) func(context.Context, lr.LogSink) lr.LocalResolver {
 	cfg := lr.LocalResolverConfig{
 		PoolSize:           poolSize,
 		UseWasmInterpreter: useWasmInterpreter,
+		Logger:             logger,
 	}
 	return func(ctx context.Context, logSink lr.LogSink) lr.LocalResolver {
 		return newProviderTelemetryResolver(

--- a/openfeature-provider/go/confidence/provider_resolve_test.go
+++ b/openfeature-provider/go/confidence/provider_resolve_test.go
@@ -2,17 +2,16 @@ package confidence
 
 import (
 	"context"
-	"log/slog"
-	"os"
 	"testing"
 
 	"github.com/open-feature/go-sdk/openfeature"
+	"google.golang.org/protobuf/proto"
+
 	lr "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/local_resolver"
 	adminv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/admin"
 	iamv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/admin"
 	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/wasm"
 	tu "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/testutil"
-	"google.golang.org/protobuf/proto"
 )
 
 func TestLocalResolverProvider_ReturnsDefaultOnError(t *testing.T) {
@@ -41,10 +40,10 @@ func TestLocalResolverProvider_ReturnsDefaultOnError(t *testing.T) {
 	unsupportedMatStore := newUnsupportedMaterializationStore()
 
 	resolverSupplier := wrapResolverSupplierWithMaterializations(func(ctx context.Context, logSink lr.LogSink) lr.LocalResolver {
-		return lr.NewLocalResolverWithPoolSize(ctx, logSink, 2)
+		return lr.NewLocalResolverWithPoolSize(ctx, logSink, newLoggerForTest(t), 2)
 	}, unsupportedMatStore)
 	// Use different client secret that won't match
-	openfeature.SetProviderAndWait(NewLocalResolverProvider(resolverSupplier, stateProvider, mockFlagLogger, "test-secret", slog.New(slog.NewTextHandler(os.Stderr, nil))))
+	openfeature.SetProviderAndWait(NewLocalResolverProvider(resolverSupplier, stateProvider, mockFlagLogger, "test-secret", newLoggerForTest(t)))
 	client := openfeature.NewClient("test-client")
 
 	evalCtx := openfeature.NewTargetlessEvaluationContext(map[string]interface{}{
@@ -89,10 +88,10 @@ func TestLocalResolverProvider_ReturnsCorrectValue(t *testing.T) {
 	unsupportedMatStore := newUnsupportedMaterializationStore()
 
 	resolverSupplier := wrapResolverSupplierWithMaterializations(func(ctx context.Context, logSink lr.LogSink) lr.LocalResolver {
-		return lr.NewLocalResolverWithPoolSize(ctx, logSink, 2)
+		return lr.NewLocalResolverWithPoolSize(ctx, logSink, newLoggerForTest(t), 2)
 	}, unsupportedMatStore)
 	// Use the correct client secret from test data
-	openfeature.SetProviderAndWait(NewLocalResolverProvider(resolverSupplier, stateProvider, mockFlagLogger, tu.TestClientSecret, slog.New(slog.NewTextHandler(os.Stderr, nil))))
+	openfeature.SetProviderAndWait(NewLocalResolverProvider(resolverSupplier, stateProvider, mockFlagLogger, tu.TestClientSecret, newLoggerForTest(t)))
 	client := openfeature.NewClient("test-client")
 
 	evalCtx := openfeature.NewTargetlessEvaluationContext(map[string]interface{}{
@@ -168,9 +167,9 @@ func TestLocalResolverProvider_DisableExposureCollectionContextKey(t *testing.T)
 	unsupportedMatStore := newUnsupportedMaterializationStore()
 
 	resolverSupplier := wrapResolverSupplierWithMaterializations(func(ctx context.Context, logSink lr.LogSink) lr.LocalResolver {
-		return lr.NewLocalResolverWithPoolSize(ctx, logSink, 2)
+		return lr.NewLocalResolverWithPoolSize(ctx, logSink, newLoggerForTest(t), 2)
 	}, unsupportedMatStore)
-	openfeature.SetProviderAndWait(NewLocalResolverProvider(resolverSupplier, stateProvider, mockFlagLogger, tu.TestClientSecret, slog.New(slog.NewTextHandler(os.Stderr, nil))))
+	openfeature.SetProviderAndWait(NewLocalResolverProvider(resolverSupplier, stateProvider, mockFlagLogger, tu.TestClientSecret, newLoggerForTest(t)))
 	client := openfeature.NewClient("test-client")
 
 	evalCtx := openfeature.NewTargetlessEvaluationContext(map[string]interface{}{
@@ -218,7 +217,7 @@ func TestLocalResolverProvider_DisableExposureCollectionConfig(t *testing.T) {
 		stateProvider,
 		mockFlagLogger,
 		tu.TestClientSecret,
-		slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		newLoggerForTest(t),
 		WithDisableExposureCollection(),
 	)
 	if err := openfeature.SetProviderAndWait(provider); err != nil {
@@ -254,7 +253,7 @@ func TestLocalResolverProvider_DisableExposureCollectionConfig(t *testing.T) {
 
 func TestLocalResolverProvider_PathNotFound(t *testing.T) {
 	ctx := context.Background()
-	runtime := lr.DefaultResolverFactory(lr.NoOpLogSink, lr.LocalResolverConfig{})
+	runtime := lr.DefaultResolverFactory(lr.NoOpLogSink, lr.LocalResolverConfig{Logger: newLoggerForTest(t)})
 	defer runtime.Close(ctx)
 
 	// Load real test state
@@ -270,10 +269,10 @@ func TestLocalResolverProvider_PathNotFound(t *testing.T) {
 	unsupportedMatStore := newUnsupportedMaterializationStore()
 
 	resolverSupplier := wrapResolverSupplierWithMaterializations(func(ctx context.Context, logSink lr.LogSink) lr.LocalResolver {
-		return lr.NewLocalResolverWithPoolSize(ctx, logSink, 2)
+		return lr.NewLocalResolverWithPoolSize(ctx, logSink, newLoggerForTest(t), 2)
 	}, unsupportedMatStore)
 	// Use the correct client secret from test data
-	openfeature.SetProviderAndWait(NewLocalResolverProvider(resolverSupplier, stateProvider, mockFlagLogger, tu.TestClientSecret, slog.New(slog.NewTextHandler(os.Stderr, nil))))
+	openfeature.SetProviderAndWait(NewLocalResolverProvider(resolverSupplier, stateProvider, mockFlagLogger, tu.TestClientSecret, newLoggerForTest(t)))
 	client := openfeature.NewClient("test-client")
 
 	evalCtx := openfeature.NewTargetlessEvaluationContext(map[string]interface{}{
@@ -338,9 +337,9 @@ func TestLocalResolverProvider_MissingMaterializations(t *testing.T) {
 		unsupportedMatStore := newUnsupportedMaterializationStore()
 
 		resolverSupplier := wrapResolverSupplierWithMaterializations(func(ctx context.Context, logSink lr.LogSink) lr.LocalResolver {
-			return lr.NewLocalResolverWithPoolSize(ctx, logSink, 2)
+			return lr.NewLocalResolverWithPoolSize(ctx, logSink, newLoggerForTest(t), 2)
 		}, unsupportedMatStore)
-		openfeature.SetProviderAndWait(NewLocalResolverProvider(resolverSupplier, stateProvider, mockFlagLogger, tu.TestClientSecret, slog.New(slog.NewTextHandler(os.Stderr, nil))))
+		openfeature.SetProviderAndWait(NewLocalResolverProvider(resolverSupplier, stateProvider, mockFlagLogger, tu.TestClientSecret, newLoggerForTest(t)))
 		client := openfeature.NewClient("test-client")
 
 		evalCtx := openfeature.NewTargetlessEvaluationContext(map[string]interface{}{
@@ -379,9 +378,9 @@ func TestLocalResolverProvider_MissingMaterializations(t *testing.T) {
 		unsupportedMatStore := newUnsupportedMaterializationStore()
 
 		resolverSupplier := wrapResolverSupplierWithMaterializations(func(ctx context.Context, logSink lr.LogSink) lr.LocalResolver {
-			return lr.NewLocalResolverWithPoolSize(ctx, logSink, 2)
+			return lr.NewLocalResolverWithPoolSize(ctx, logSink, newLoggerForTest(t), 2)
 		}, unsupportedMatStore)
-		openfeature.SetProviderAndWait(NewLocalResolverProvider(resolverSupplier, stateProvider, mockFlagLogger, "test-secret", slog.New(slog.NewTextHandler(os.Stderr, nil))))
+		openfeature.SetProviderAndWait(NewLocalResolverProvider(resolverSupplier, stateProvider, mockFlagLogger, "test-secret", newLoggerForTest(t)))
 		client := openfeature.NewClient("test-client")
 
 		evalCtx := openfeature.NewTargetlessEvaluationContext(map[string]interface{}{

--- a/openfeature-provider/go/confidence/retry_test.go
+++ b/openfeature-provider/go/confidence/retry_test.go
@@ -1,22 +1,20 @@
-package confidence_test
+package confidence
 
 import (
 	"context"
-	"log/slog"
 	"net"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence"
-	fl "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/flag_logger"
-	resolverv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolverinternal"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
+
+	fl "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/flag_logger"
+	resolverv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolverinternal"
 )
 
 func TestRetryOnUnavailable(t *testing.T) {
@@ -36,7 +34,7 @@ func TestRetryOnUnavailable(t *testing.T) {
 			return lis.DialContext(ctx)
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultServiceConfig(confidence.RetryServiceConfig),
+		grpc.WithDefaultServiceConfig(RetryServiceConfig),
 	)
 	if err != nil {
 		t.Fatalf("Failed to dial: %v", err)
@@ -44,7 +42,7 @@ func TestRetryOnUnavailable(t *testing.T) {
 	t.Cleanup(func() { conn.Close() })
 
 	stub := resolverv1.NewInternalFlagLoggerServiceClient(conn)
-	logger := fl.NewGrpcWasmFlagLogger(stub, "test-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	logger := fl.NewGrpcWasmFlagLogger(stub, "test-secret", newLoggerForTest(t))
 
 	logger.Write(&resolverv1.WriteFlagLogsRequest{
 		FlagAssigned: []*resolverv1.FlagAssigned{{ResolveId: "r1"}},
@@ -72,7 +70,7 @@ func TestNoRetryOnPermissionDenied(t *testing.T) {
 			return lis.DialContext(ctx)
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultServiceConfig(confidence.RetryServiceConfig),
+		grpc.WithDefaultServiceConfig(RetryServiceConfig),
 	)
 	if err != nil {
 		t.Fatalf("Failed to dial: %v", err)
@@ -80,7 +78,7 @@ func TestNoRetryOnPermissionDenied(t *testing.T) {
 	t.Cleanup(func() { conn.Close() })
 
 	stub := resolverv1.NewInternalFlagLoggerServiceClient(conn)
-	logger := fl.NewGrpcWasmFlagLogger(stub, "test-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	logger := fl.NewGrpcWasmFlagLogger(stub, "test-secret", newLoggerForTest(t))
 
 	logger.Write(&resolverv1.WriteFlagLogsRequest{
 		FlagAssigned: []*resolverv1.FlagAssigned{{ResolveId: "r1"}},
@@ -109,7 +107,7 @@ func TestAllRetriesExhausted(t *testing.T) {
 			return lis.DialContext(ctx)
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultServiceConfig(confidence.RetryServiceConfig),
+		grpc.WithDefaultServiceConfig(RetryServiceConfig),
 	)
 	if err != nil {
 		t.Fatalf("Failed to dial: %v", err)
@@ -117,7 +115,7 @@ func TestAllRetriesExhausted(t *testing.T) {
 	t.Cleanup(func() { conn.Close() })
 
 	stub := resolverv1.NewInternalFlagLoggerServiceClient(conn)
-	logger := fl.NewGrpcWasmFlagLogger(stub, "test-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	logger := fl.NewGrpcWasmFlagLogger(stub, "test-secret", newLoggerForTest(t))
 
 	logger.Write(&resolverv1.WriteFlagLogsRequest{
 		FlagAssigned: []*resolverv1.FlagAssigned{{ResolveId: "r1"}},
@@ -146,7 +144,7 @@ func TestShutdownDuringRetries(t *testing.T) {
 			return lis.DialContext(ctx)
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultServiceConfig(confidence.RetryServiceConfig),
+		grpc.WithDefaultServiceConfig(RetryServiceConfig),
 	)
 	if err != nil {
 		t.Fatalf("Failed to dial: %v", err)
@@ -154,7 +152,7 @@ func TestShutdownDuringRetries(t *testing.T) {
 	t.Cleanup(func() { conn.Close() })
 
 	stub := resolverv1.NewInternalFlagLoggerServiceClient(conn)
-	logger := fl.NewGrpcWasmFlagLogger(stub, "test-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	logger := fl.NewGrpcWasmFlagLogger(stub, "test-secret", newLoggerForTest(t))
 
 	logger.Write(&resolverv1.WriteFlagLogsRequest{
 		FlagAssigned: []*resolverv1.FlagAssigned{{ResolveId: "r1"}},
@@ -186,7 +184,7 @@ func TestTransportHooksPreserveRetry(t *testing.T) {
 	t.Cleanup(srv.Stop)
 
 	baseOpts := []grpc.DialOption{
-		grpc.WithDefaultServiceConfig(confidence.RetryServiceConfig),
+		grpc.WithDefaultServiceConfig(RetryServiceConfig),
 	}
 	opts := append([]grpc.DialOption{}, baseOpts...)
 	opts = append(opts,
@@ -203,7 +201,7 @@ func TestTransportHooksPreserveRetry(t *testing.T) {
 	t.Cleanup(func() { conn.Close() })
 
 	stub := resolverv1.NewInternalFlagLoggerServiceClient(conn)
-	logger := fl.NewGrpcWasmFlagLogger(stub, "test-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	logger := fl.NewGrpcWasmFlagLogger(stub, "test-secret", newLoggerForTest(t))
 
 	logger.Write(&resolverv1.WriteFlagLogsRequest{
 		FlagAssigned: []*resolverv1.FlagAssigned{{ResolveId: "r1"}},
@@ -232,7 +230,7 @@ func TestMultipleWritesWithRetryConfig(t *testing.T) {
 			return lis.DialContext(ctx)
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultServiceConfig(confidence.RetryServiceConfig),
+		grpc.WithDefaultServiceConfig(RetryServiceConfig),
 	)
 	if err != nil {
 		t.Fatalf("Failed to dial: %v", err)
@@ -240,7 +238,7 @@ func TestMultipleWritesWithRetryConfig(t *testing.T) {
 	t.Cleanup(func() { conn.Close() })
 
 	stub := resolverv1.NewInternalFlagLoggerServiceClient(conn)
-	logger := fl.NewGrpcWasmFlagLogger(stub, "test-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	logger := fl.NewGrpcWasmFlagLogger(stub, "test-secret", newLoggerForTest(t))
 
 	for i := 0; i < 5; i++ {
 		logger.Write(&resolverv1.WriteFlagLogsRequest{

--- a/openfeature-provider/go/confidence/retry_test.go
+++ b/openfeature-provider/go/confidence/retry_test.go
@@ -1,7 +1,9 @@
-package confidence
+package confidence_test
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"net"
 	"sync/atomic"
 	"testing"
@@ -13,9 +15,14 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 
+	"github.com/spotify/confidence-resolver/openfeature-provider/go/confidence"
 	fl "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/flag_logger"
 	resolverv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/resolverinternal"
 )
+
+func newLoggerForTest(_ testing.TB) *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
 
 func TestRetryOnUnavailable(t *testing.T) {
 	var callCount atomic.Int32
@@ -34,7 +41,7 @@ func TestRetryOnUnavailable(t *testing.T) {
 			return lis.DialContext(ctx)
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultServiceConfig(RetryServiceConfig),
+		grpc.WithDefaultServiceConfig(confidence.RetryServiceConfig),
 	)
 	if err != nil {
 		t.Fatalf("Failed to dial: %v", err)
@@ -70,7 +77,7 @@ func TestNoRetryOnPermissionDenied(t *testing.T) {
 			return lis.DialContext(ctx)
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultServiceConfig(RetryServiceConfig),
+		grpc.WithDefaultServiceConfig(confidence.RetryServiceConfig),
 	)
 	if err != nil {
 		t.Fatalf("Failed to dial: %v", err)
@@ -107,7 +114,7 @@ func TestAllRetriesExhausted(t *testing.T) {
 			return lis.DialContext(ctx)
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultServiceConfig(RetryServiceConfig),
+		grpc.WithDefaultServiceConfig(confidence.RetryServiceConfig),
 	)
 	if err != nil {
 		t.Fatalf("Failed to dial: %v", err)
@@ -144,7 +151,7 @@ func TestShutdownDuringRetries(t *testing.T) {
 			return lis.DialContext(ctx)
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultServiceConfig(RetryServiceConfig),
+		grpc.WithDefaultServiceConfig(confidence.RetryServiceConfig),
 	)
 	if err != nil {
 		t.Fatalf("Failed to dial: %v", err)
@@ -184,7 +191,7 @@ func TestTransportHooksPreserveRetry(t *testing.T) {
 	t.Cleanup(srv.Stop)
 
 	baseOpts := []grpc.DialOption{
-		grpc.WithDefaultServiceConfig(RetryServiceConfig),
+		grpc.WithDefaultServiceConfig(confidence.RetryServiceConfig),
 	}
 	opts := append([]grpc.DialOption{}, baseOpts...)
 	opts = append(opts,
@@ -230,7 +237,7 @@ func TestMultipleWritesWithRetryConfig(t *testing.T) {
 			return lis.DialContext(ctx)
 		}),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithDefaultServiceConfig(RetryServiceConfig),
+		grpc.WithDefaultServiceConfig(confidence.RetryServiceConfig),
 	)
 	if err != nil {
 		t.Fatalf("Failed to dial: %v", err)

--- a/openfeature-provider/go/confidence/state_fetcher.go
+++ b/openfeature-provider/go/confidence/state_fetcher.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"sync/atomic"
 	"time"
@@ -32,7 +31,7 @@ type FlagsAdminStateFetcher struct {
 	accountID        atomic.Value // stores string
 	logDestinations  atomic.Value // stores []admin.LogDestination
 	HTTPClient       *http.Client // Exported for testing
-	logger           *slog.Logger
+	logger           Logger
 }
 
 // Compile-time interface conformance check
@@ -41,7 +40,7 @@ var _ StateProvider = (*FlagsAdminStateFetcher)(nil)
 // NewFlagsAdminStateFetcher creates a new FlagsAdminStateFetcher
 func NewFlagsAdminStateFetcher(
 	clientSecret string,
-	logger *slog.Logger,
+	logger Logger,
 ) *FlagsAdminStateFetcher {
 	return NewFlagsAdminStateFetcherWithTransport(clientSecret, logger, http.DefaultTransport)
 }
@@ -49,7 +48,7 @@ func NewFlagsAdminStateFetcher(
 // NewFlagsAdminStateFetcherWithTransport creates a new FlagsAdminStateFetcher with a custom HTTP transport.
 func NewFlagsAdminStateFetcherWithTransport(
 	clientSecret string,
-	logger *slog.Logger,
+	logger Logger,
 	transport http.RoundTripper,
 ) *FlagsAdminStateFetcher {
 	return NewFlagsAdminStateFetcherWithEncryption(clientSecret, "", logger, transport)
@@ -59,7 +58,7 @@ func NewFlagsAdminStateFetcherWithTransport(
 func NewFlagsAdminStateFetcherWithEncryption(
 	clientSecret string,
 	encryptionKey string,
-	logger *slog.Logger,
+	logger Logger,
 	transport http.RoundTripper,
 ) *FlagsAdminStateFetcher {
 	f := &FlagsAdminStateFetcher{

--- a/openfeature-provider/go/confidence/state_fetcher_test.go
+++ b/openfeature-provider/go/confidence/state_fetcher_test.go
@@ -2,16 +2,15 @@ package confidence
 
 import (
 	"context"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"testing"
 	"time"
 
-	adminv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/admin"
 	"google.golang.org/protobuf/proto"
+
+	adminv1 "github.com/spotify/confidence-resolver/openfeature-provider/go/confidence/internal/proto/admin"
 )
 
 // testTransport is a custom RoundTripper that redirects all requests to a test server
@@ -31,7 +30,7 @@ func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func TestNewFlagsAdminStateFetcher(t *testing.T) {
-	fetcher := NewFlagsAdminStateFetcher("test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	fetcher := NewFlagsAdminStateFetcher("test-client-secret", newLoggerForTest(t))
 
 	if fetcher == nil {
 		t.Fatal("Expected fetcher to be created, got nil")
@@ -51,7 +50,7 @@ func TestNewFlagsAdminStateFetcher(t *testing.T) {
 }
 
 func TestFlagsAdminStateFetcher_GetRawState(t *testing.T) {
-	fetcher := NewFlagsAdminStateFetcher("test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	fetcher := NewFlagsAdminStateFetcher("test-client-secret", newLoggerForTest(t))
 
 	// Initial state should be empty but not nil
 	state := fetcher.GetRawState()
@@ -61,7 +60,7 @@ func TestFlagsAdminStateFetcher_GetRawState(t *testing.T) {
 }
 
 func TestFlagsAdminStateFetcher_GetAccountID(t *testing.T) {
-	fetcher := NewFlagsAdminStateFetcher("test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	fetcher := NewFlagsAdminStateFetcher("test-client-secret", newLoggerForTest(t))
 
 	// Initially empty
 	if fetcher.GetAccountID() != "" {
@@ -97,7 +96,7 @@ func TestFlagsAdminStateFetcher_Reload_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	fetcher := NewFlagsAdminStateFetcher("test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	fetcher := NewFlagsAdminStateFetcher("test-client-secret", newLoggerForTest(t))
 	// Use custom transport to redirect to test server
 	fetcher.HTTPClient = &http.Client{
 		Timeout:   30 * time.Second,
@@ -162,7 +161,7 @@ func TestFlagsAdminStateFetcher_Reload_NotModified(t *testing.T) {
 	}))
 	defer server.Close()
 
-	fetcher := NewFlagsAdminStateFetcher("test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	fetcher := NewFlagsAdminStateFetcher("test-client-secret", newLoggerForTest(t))
 	fetcher.HTTPClient = &http.Client{
 		Timeout:   30 * time.Second,
 		Transport: &testTransport{testServerURL: server.URL},
@@ -226,7 +225,7 @@ func TestFlagsAdminStateFetcher_Reload_IfModifiedSinceFallback(t *testing.T) {
 	}))
 	defer server.Close()
 
-	fetcher := NewFlagsAdminStateFetcher("test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	fetcher := NewFlagsAdminStateFetcher("test-client-secret", newLoggerForTest(t))
 	fetcher.HTTPClient = &http.Client{
 		Timeout:   30 * time.Second,
 		Transport: &testTransport{testServerURL: server.URL},
@@ -277,7 +276,7 @@ func TestFlagsAdminStateFetcher_Reload_NoValidators(t *testing.T) {
 	}))
 	defer server.Close()
 
-	fetcher := NewFlagsAdminStateFetcher("test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	fetcher := NewFlagsAdminStateFetcher("test-client-secret", newLoggerForTest(t))
 	fetcher.HTTPClient = &http.Client{
 		Timeout:   30 * time.Second,
 		Transport: &testTransport{testServerURL: server.URL},
@@ -302,7 +301,7 @@ func TestFlagsAdminStateFetcher_Reload_Error(t *testing.T) {
 	}))
 	defer server.Close()
 
-	fetcher := NewFlagsAdminStateFetcher("test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	fetcher := NewFlagsAdminStateFetcher("test-client-secret", newLoggerForTest(t))
 	fetcher.HTTPClient = &http.Client{
 		Timeout:   30 * time.Second,
 		Transport: &testTransport{testServerURL: server.URL},
@@ -333,7 +332,7 @@ func TestFlagsAdminStateFetcher_Provide(t *testing.T) {
 	}))
 	defer server.Close()
 
-	fetcher := NewFlagsAdminStateFetcher("test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	fetcher := NewFlagsAdminStateFetcher("test-client-secret", newLoggerForTest(t))
 	fetcher.HTTPClient = &http.Client{
 		Timeout:   30 * time.Second,
 		Transport: &testTransport{testServerURL: server.URL},
@@ -380,7 +379,7 @@ func TestFlagsAdminStateFetcher_Provide_ReturnsStateOnError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	fetcher := NewFlagsAdminStateFetcher("test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	fetcher := NewFlagsAdminStateFetcher("test-client-secret", newLoggerForTest(t))
 	fetcher.HTTPClient = &http.Client{
 		Timeout:   30 * time.Second,
 		Transport: &testTransport{testServerURL: server.URL},
@@ -421,7 +420,7 @@ func TestFlagsAdminStateFetcher_HTTPTimeout(t *testing.T) {
 	}))
 	defer server.Close()
 
-	fetcher := NewFlagsAdminStateFetcher("test-client-secret", slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	fetcher := NewFlagsAdminStateFetcher("test-client-secret", newLoggerForTest(t))
 	// Set short timeout for test
 	fetcher.HTTPClient = &http.Client{
 		Timeout:   100 * time.Millisecond,


### PR DESCRIPTION
## Summary

- accept a small `Logger` interface instead of requiring `*slog.Logger`
- thread custom logging through current resolver and multi-destination logging paths
- use a no-op logger when none is configured
- document the interface and keep test loggers race-safe

## Attribution

This revamps and supersedes [#494](https://github.com/spotify/confidence-resolver/pull/494) by @lbcjbb. The original feature commit retains Jean-Baptiste Bronisz as its Git author.

## Testing

- `go test ./confidence/... -skip '^(TestFlagResolve_WithMaterialized|TestFlagResolve_WithEncryptedState|TestFlagLogs_)'`
- `go vet ./...`
- focused `-race` test for asynchronous provider shutdown logging

The live e2e tests require Confidence credentials and are left to CI.
