### PR TITLE
fix(python): offload async flag evaluation

### DIFF
--- a/openfeature-provider/python/README.md
+++ b/openfeature-provider/python/README.md
@@ -59,7 +59,10 @@ from openfeature.evaluation_context import EvaluationContext
 from confidence import ConfidenceProvider
 
 # Create and register the provider
-provider = ConfidenceProvider(client_secret="your-client-secret")
+provider = ConfidenceProvider(
+    client_secret="your-client-secret",
+    encryption_key="your-encryption-key",
+)
 api.set_provider_and_wait(provider)
 
 # Get a client
@@ -80,6 +83,27 @@ print(f"Flag value: {enabled}")
 
 # Don't forget to shutdown when your application exits (see Shutdown section)
 ```
+
+## Async Evaluation
+
+In an asyncio application, use the OpenFeature client's async evaluation methods:
+
+```python
+# After registering the provider, as shown above:
+async def feature_enabled() -> bool:
+    return await client.get_boolean_value_async(
+        "test-flag.enabled", default_value=False, evaluation_context=context
+    )
+```
+
+Async evaluation is supported for boolean, string, integer, float, and object flags.
+The provider runs evaluation in a worker thread, so waiting for the WASM resolver
+or materialization storage leaves the event loop free to handle other requests.
+Evaluations still share one WASM instance protected by a lock.
+
+Provider initialization and shutdown remain synchronous; perform them outside
+the event loop or offload them with `asyncio.to_thread`. Cancelling an async
+evaluation does not stop work already running in its worker thread.
 
 ## Evaluation Context
 

--- a/openfeature-provider/python/src/confidence/provider.py
+++ b/openfeature-provider/python/src/confidence/provider.py
@@ -4,6 +4,7 @@ This module provides the ConfidenceProvider class that implements the OpenFeatur
 AbstractProvider interface for local flag resolution using the Confidence WASM resolver.
 """
 
+import asyncio
 import json
 import logging
 import threading
@@ -582,6 +583,17 @@ class ConfidenceProvider(AbstractProvider):
             type_convert=lambda v: v,
         )
 
+    async def resolve_boolean_details_async(
+        self,
+        flag_key: str,
+        default_value: bool,
+        evaluation_context: Optional[EvaluationContext] = None,
+    ) -> FlagResolutionDetails[bool]:
+        """Resolve a boolean flag without blocking the event loop."""
+        return await asyncio.to_thread(
+            self.resolve_boolean_details, flag_key, default_value, evaluation_context
+        )
+
     def resolve_string_details(
         self,
         flag_key: str,
@@ -595,6 +607,17 @@ class ConfidenceProvider(AbstractProvider):
             evaluation_context,
             type_check=lambda v: isinstance(v, str),
             type_convert=lambda v: v,
+        )
+
+    async def resolve_string_details_async(
+        self,
+        flag_key: str,
+        default_value: str,
+        evaluation_context: Optional[EvaluationContext] = None,
+    ) -> FlagResolutionDetails[str]:
+        """Resolve a string flag without blocking the event loop."""
+        return await asyncio.to_thread(
+            self.resolve_string_details, flag_key, default_value, evaluation_context
         )
 
     def resolve_integer_details(
@@ -616,6 +639,17 @@ class ConfidenceProvider(AbstractProvider):
             type_convert=lambda v: int(v),
         )
 
+    async def resolve_integer_details_async(
+        self,
+        flag_key: str,
+        default_value: int,
+        evaluation_context: Optional[EvaluationContext] = None,
+    ) -> FlagResolutionDetails[int]:
+        """Resolve an integer flag without blocking the event loop."""
+        return await asyncio.to_thread(
+            self.resolve_integer_details, flag_key, default_value, evaluation_context
+        )
+
     def resolve_float_details(
         self,
         flag_key: str,
@@ -634,6 +668,17 @@ class ConfidenceProvider(AbstractProvider):
             type_convert=lambda v: float(v),
         )
 
+    async def resolve_float_details_async(
+        self,
+        flag_key: str,
+        default_value: float,
+        evaluation_context: Optional[EvaluationContext] = None,
+    ) -> FlagResolutionDetails[float]:
+        """Resolve a float flag without blocking the event loop."""
+        return await asyncio.to_thread(
+            self.resolve_float_details, flag_key, default_value, evaluation_context
+        )
+
     def resolve_object_details(
         self,
         flag_key: str,
@@ -647,6 +692,17 @@ class ConfidenceProvider(AbstractProvider):
             evaluation_context,
             type_check=lambda v: isinstance(v, dict),
             type_convert=lambda v: v,
+        )
+
+    async def resolve_object_details_async(
+        self,
+        flag_key: str,
+        default_value: Dict[str, Any],
+        evaluation_context: Optional[EvaluationContext] = None,
+    ) -> FlagResolutionDetails[Dict[str, Any]]:
+        """Resolve an object flag without blocking the event loop."""
+        return await asyncio.to_thread(
+            self.resolve_object_details, flag_key, default_value, evaluation_context
         )
 
     def _resolve_object(

--- a/openfeature-provider/python/tests/test_async_provider.py
+++ b/openfeature-provider/python/tests/test_async_provider.py
@@ -1,0 +1,78 @@
+"""Async evaluations must leave the event loop responsive during contention."""
+
+import asyncio
+import threading
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from openfeature.evaluation_context import EvaluationContext
+from openfeature.exception import ErrorCode
+from openfeature.flag_evaluation import Reason
+
+from confidence.local_resolver import LocalResolver
+from confidence.provider import ConfidenceProvider
+from confidence.proto.confidence.flags.resolver.v1 import types_pb2
+from confidence.proto.confidence.wasm import wasm_api_pb2
+
+
+@pytest.mark.parametrize(
+    "kind,default,value",
+    [
+        ("boolean", False, True),
+        ("string", "fallback", "resolved"),
+        ("integer", 0, 42),
+        ("float", 0.0, 1.5),
+        ("object", {}, {"enabled": True}),
+    ],
+)
+@pytest.mark.parametrize("missing", [False, True], ids=["matched", "missing"])
+async def test_async_resolution_during_contention(
+    kind: str, default: Any, value: Any, missing: bool
+) -> None:
+    provider = ConfidenceProvider(client_secret="test-secret", encryption_key="00" * 32)
+    resolver = Mock(spec=LocalResolver)
+    provider._resolver = resolver
+    resolver.flush_logs.return_value = b""
+    response = wasm_api_pb2.ResolveProcessResponse()
+    response.resolved.SetInParent()
+    if not missing:
+        flag = response.resolved.response.resolved_flags.add(
+            flag="flags/test",
+            variant="flags/test/variants/on",
+            reason=types_pb2.RESOLVE_REASON_MATCH,
+        )
+        flag.value.update({"value": value})
+
+    loop_thread = threading.get_ident()
+    loop_progressed = threading.Event()
+
+    def resolve(request: wasm_api_pb2.ResolveProcessRequest) -> Any:
+        assert threading.get_ident() != loop_thread
+        assert loop_progressed.is_set()
+        assert provider._resolver_lock.locked()
+        assert (
+            request.without_materializations.evaluation_context["targeting_key"]
+            == "user"
+        )
+        return response
+
+    resolver.resolve_process.side_effect = resolve
+    provider._resolver_lock.acquire()
+    # A separate thread releases the lock even if a regression blocks the loop.
+    release = threading.Timer(0.05, provider._resolver_lock.release)
+    release.start()
+    asyncio.get_running_loop().call_soon(loop_progressed.set)
+    try:
+        result = await getattr(provider, f"resolve_{kind}_details_async")(
+            "test.value", default, EvaluationContext(targeting_key="user")
+        )
+        assert result.value == (default if missing else value)
+        assert result.error_code == (ErrorCode.FLAG_NOT_FOUND if missing else None)
+        assert result.reason == (Reason.ERROR if missing else Reason.TARGETING_MATCH)
+        assert result.variant == (None if missing else "flags/test/variants/on")
+        resolver.resolve_process.assert_called_once()
+        resolver.register_resolve.assert_called_once()
+    finally:
+        release.join()
+        provider.shutdown()


### PR DESCRIPTION
Async flag evaluation inherited OpenFeature's synchronous fallback, so waiting for the WASM lock could block the event loop. Override all five async evaluation methods with `asyncio.to_thread`, reusing synchronous evaluation and retaining the single locked WASM instance.

Adds contention regressions for all five types, including missing-flag fallbacks, and documents async usage and cancellation behavior.

Validation: 134 Python unit tests passed; Ruff lint/format, mypy, and `git diff --check` passed.
